### PR TITLE
/aldwulf/basilisks/basi_hole entrance fixes

### DIFF
--- a/maps/world/world_100_124
+++ b/maps/world/world_100_124
@@ -4,7 +4,7 @@ region aldwulf
 width 50
 height 50
 msg
-Modified: 2020-01-22 Acer
+Modified: 2020-09-03 Fauzin
 endmsg
 outdoor 1
 tile_path_1 world_100_123
@@ -6171,24 +6171,6 @@ arch swamp
 x 16
 y 14
 end
-arch phole_2
-slaying basi_hole
-hp 10
-sp 14
-x 16
-y 14
-end
-arch magic_mouth
-msg
-You hear the sounds of hundreds of
-hungry basilisks from downstairs - but
-something is strange: it seems to be
-very hot there but you ever thought
-that basilisks hate fire...
-endmsg
-x 16
-y 14
-end
 arch swamp
 x 16
 y 15
@@ -9826,6 +9808,17 @@ name Stinking Hole
 slaying /aldwulf/basilisks/basi_hole
 hp 10
 sp 14
+x 31
+y 19
+end
+arch magic_mouth
+msg
+You hear the sounds of hundreds of
+hungry basilisks from downstairs - but
+something is strange: it seems to be
+very hot there but you ever thought
+that basilisks hate fire...
+endmsg
 x 31
 y 19
 end


### PR DESCRIPTION
* Fake entrance to "/aldwulf/basilisks/basi_hole" on "/world/world_100_124" was removed.
* Moved magic mouth on top of actual entrance.