### PR TITLE
Various fixes fauzin

### DIFF
--- a/maps/aldwulf/dragon_term
+++ b/maps/aldwulf/dragon_term
@@ -1,13 +1,14 @@
 arch map
-region aldwulf
 name dragon_term
 difficulty 18
+region aldwulf
 width 16
 height 26
 msg
 Creator: Gnat the Gnu
 Email: gnu@foo.bar
 Date: Sat Dec 29 19:27:51 2001
+Modified: 2020-09-04 Fauzin
 endmsg
 end
 arch desert
@@ -1031,10 +1032,14 @@ end
 arch cobblestones2
 x 6
 end
-arch stwall_2_1_2
+arch stwall_3_3
 x 6
 end
-arch sea
+arch cobblestones2
+x 6
+y 1
+end
+arch stwall_2_1_1
 x 6
 y 1
 end
@@ -1042,7 +1047,7 @@ arch cobblestones2
 x 6
 y 2
 end
-arch sea
+arch stwall_2_1_1
 x 6
 y 2
 end
@@ -1050,7 +1055,7 @@ arch cobblestones2
 x 6
 y 3
 end
-arch sea
+arch stwall_2_1_1
 x 6
 y 3
 end
@@ -1062,7 +1067,7 @@ arch sea
 x 6
 y 4
 end
-arch stwall_2_1_2
+arch stwall_3_1
 x 6
 y 4
 end
@@ -1726,10 +1731,14 @@ end
 arch cobblestones2
 x 10
 end
-arch stwall_2_1_2
+arch stwall_3_3
 x 10
 end
-arch sea
+arch cobblestones2
+x 10
+y 1
+end
+arch stwall_2_1_1
 x 10
 y 1
 end
@@ -1737,7 +1746,7 @@ arch cobblestones2
 x 10
 y 2
 end
-arch sea
+arch stwall_2_1_1
 x 10
 y 2
 end
@@ -1745,7 +1754,7 @@ arch cobblestones2
 x 10
 y 3
 end
-arch sea
+arch stwall_2_1_1
 x 10
 y 3
 end
@@ -1757,7 +1766,7 @@ arch sea
 x 10
 y 4
 end
-arch stwall_2_1_2
+arch stwall_3_1
 x 10
 y 4
 end

--- a/maps/aldwulf/smaug_hole_s
+++ b/maps/aldwulf/smaug_hole_s
@@ -1,6 +1,7 @@
 arch map
-region aldwulf
+name Smaugs hoard
 difficulty 100
+region aldwulf
 width 20
 height 30
 enter_x 1
@@ -9,6 +10,7 @@ msg
 Creator: Gnat the Gnu
 Email: gnu@foo.bar
 Date: Mon Feb 18 20:20:14 2002
+Modified: 2020-09-04 Fauzin
 endmsg
 end
 arch pstone_1
@@ -1138,13 +1140,13 @@ end
 arch gem
 title of exceptional beauty
 face pretty_crystal.111
-is_animated 0
 x 8
 y 2
 speed 0.000000
 nrof 74
 value 40000
 weight 65
+is_animated 0
 end
 arch pstone_1
 x 8
@@ -1802,7 +1804,7 @@ x 11
 y 29
 end
 arch invis_exit
-slaying smaug_island
+slaying /aldwulf/smaug_island
 hp 8
 sp 11
 x 11
@@ -2592,13 +2594,13 @@ end
 arch gem
 title of exceptional beauty
 face pretty_crystal.111
-is_animated 0
 x 16
 y 5
 speed 0.000000
 nrof 87
 value 40000
 weight 65
+is_animated 0
 end
 arch pstone_1
 x 16

--- a/maps/aldwulf/smaug_island
+++ b/maps/aldwulf/smaug_island
@@ -1,12 +1,13 @@
 arch map
-region aldwulf
 name smaug_island
+region aldwulf
 width 35
 height 30
 msg
 Creator: Gnat the Gnu
 Email: gnu@foo.bar
 Date: Thu Feb  7 11:29:42 2002
+Modified: 2020-09-04 Fauzin
 endmsg
 end
 arch wasteland
@@ -1136,7 +1137,7 @@ x 8
 y 10
 end
 arch mountain_cave
-slaying smaug_hole_s
+slaying /aldwulf/smaug_hole_s
 hp 11
 sp 28
 x 8
@@ -2441,7 +2442,7 @@ x 18
 y 11
 end
 arch rowboat
-slaying water_town
+slaying /world/world_100_125
 hp 13
 sp 17
 x 18

--- a/maps/darcap/darcap/circus/bigtop
+++ b/maps/darcap/darcap/circus/bigtop
@@ -8,7 +8,7 @@ enter_x 17
 enter_y 30
 msg
 Created:  1999-01-27 Cater & Wade & Fouras (john_cater@yahoo.com)
-Modified: 2020-08-23 Acer
+Modified: 2020-09-04 Fauzin
 endmsg
 end
 arch grassmedium
@@ -1418,7 +1418,8 @@ y 15
 end
 arch goldfloor
 name drop 100 gold coins
-food 100
+slaying money
+food 1000
 x 6
 y 15
 connected 1
@@ -1433,7 +1434,8 @@ y 16
 end
 arch goldfloor
 name drop 100 gold coins
-food 100
+slaying money
+food 1000
 x 6
 y 16
 connected 5
@@ -4363,7 +4365,8 @@ y 15
 end
 arch goldfloor
 name drop 200 gold coins
-food 200
+slaying money
+food 2000
 x 20
 y 15
 connected 2
@@ -4378,7 +4381,8 @@ y 16
 end
 arch goldfloor
 name drop 200 gold coins
-food 200
+slaying money
+food 2000
 x 20
 y 16
 connected 6
@@ -6149,7 +6153,8 @@ y 15
 end
 arch goldfloor
 name drop 200 gold coins
-food 200
+slaying money
+food 2000
 x 27
 y 15
 connected 3
@@ -6164,7 +6169,8 @@ y 16
 end
 arch goldfloor
 name drop 200 gold coins
-food 200
+slaying money
+food 2000
 x 27
 y 16
 connected 7
@@ -9080,7 +9086,8 @@ y 15
 end
 arch goldfloor
 name drop 100 gold coins
-food 100
+slaying money
+food 1000
 x 41
 y 15
 connected 4
@@ -9095,7 +9102,8 @@ y 16
 end
 arch goldfloor
 name drop 100 gold coins
-food 100
+slaying money
+food 1000
 x 41
 y 16
 connected 8

--- a/maps/darcap/darcap/circus/chess
+++ b/maps/darcap/darcap/circus/chess
@@ -6,7 +6,7 @@ width 20
 height 16
 msg
 Created:  1999-03-10 Cater & Wade (john_cater@yahoo.com)
-Modified: 2020-08-23 Acer
+Modified: 2020-09-04 Fauzin
 endmsg
 end
 arch pstone_1
@@ -294,7 +294,7 @@ arch pstone_1
 x 4
 y 4
 end
-arch exit
+arch invis_exit
 slaying /world/world_116_102
 hp 42
 sp 16
@@ -309,7 +309,7 @@ arch pstone_1
 x 4
 y 5
 end
-arch exit
+arch invis_exit
 slaying /world/world_116_102
 hp 42
 sp 16

--- a/maps/darcap/darcap/circus/chess
+++ b/maps/darcap/darcap/circus/chess
@@ -629,7 +629,8 @@ y 3
 end
 arch goldfloor
 name drop 20 gold coins
-food 20
+slaying money
+food 200
 x 6
 y 3
 connected 1
@@ -644,7 +645,8 @@ y 4
 end
 arch goldfloor
 name drop 20 gold coins
-food 20
+slaying money
+food 200
 x 6
 y 4
 connected 1
@@ -659,7 +661,8 @@ y 5
 end
 arch goldfloor
 name drop 20 gold coins
-food 20
+slaying money
+food 200
 x 6
 y 5
 connected 1
@@ -674,7 +677,8 @@ y 6
 end
 arch goldfloor
 name drop 20 gold coins
-food 20
+slaying money
+food 200
 x 6
 y 6
 connected 1

--- a/maps/darcap/darcap/circus/double
+++ b/maps/darcap/darcap/circus/double
@@ -6,7 +6,7 @@ width 36
 height 32
 msg
 Created:  1999-01-29 Cater&Wade&Fouras (john_cater@yahoo.com)
-Modified: 2020-08-23 Acer
+Modified: 2020-09-04 Fauzin
 endmsg
 end
 arch pstone_1
@@ -978,7 +978,8 @@ y 10
 end
 arch goldfloor
 name drop 2 gold coins
-food 2
+slaying money
+food 20
 x 6
 y 10
 connected 94
@@ -1005,7 +1006,8 @@ y 14
 end
 arch goldfloor
 name drop 20 gold coins
-food 20
+slaying money
+food 200
 x 6
 y 14
 connected 96
@@ -1016,7 +1018,8 @@ y 15
 end
 arch goldfloor
 name drop 20 gold coins
-food 20
+slaying money
+food 200
 x 6
 y 15
 connected 96
@@ -1027,7 +1030,8 @@ y 16
 end
 arch goldfloor
 name drop 20 gold coins
-food 20
+slaying money
+food 200
 x 6
 y 16
 connected 96
@@ -1038,7 +1042,8 @@ y 17
 end
 arch goldfloor
 name drop 20 gold coins
-food 20
+slaying money
+food 200
 x 6
 y 17
 connected 96
@@ -1506,7 +1511,8 @@ y 6
 end
 arch goldfloor
 name drop 4 gold coins
-food 4
+slaying money
+food 40
 x 9
 y 6
 connected 93
@@ -1663,7 +1669,8 @@ y 3
 end
 arch goldfloor
 name drop 8 gold coins
-food 8
+slaying money
+food 80
 x 10
 y 3
 connected 92
@@ -1754,7 +1761,8 @@ y 20
 end
 arch goldfloor
 name drop 8000 gold coins
-food 8000
+slaying money
+food 80000
 x 10
 y 20
 connected 82
@@ -2207,7 +2215,8 @@ y 29
 end
 arch goldfloor
 name drop 4000 gold coins
-food 4000
+slaying money
+food 40000
 x 12
 y 29
 connected 83
@@ -2861,7 +2870,8 @@ y 2
 end
 arch goldfloor
 name drop 16 gold coins
-food 16
+slaying money
+food 160
 x 17
 y 2
 connected 91
@@ -3093,7 +3103,8 @@ y 15
 end
 arch goldfloor
 name drop 16000 gold coins
-food 16000
+slaying money
+food 160000
 x 18
 y 15
 connected 81
@@ -3330,7 +3341,8 @@ y 27
 end
 arch goldfloor
 name drop 2000 gold coins
-food 2000
+slaying money
+food 20000
 x 19
 y 27
 connected 84
@@ -3833,7 +3845,8 @@ y 3
 end
 arch goldfloor
 name drop 32 gold coins
-food 32
+slaying money
+food 320
 x 23
 y 3
 connected 90
@@ -4487,7 +4500,8 @@ y 22
 end
 arch goldfloor
 name drop 500 gold coins
-food 500
+slaying money
+food 5000
 x 26
 y 22
 connected 86
@@ -4527,7 +4541,8 @@ y 29
 end
 arch goldfloor
 name drop 1000 gold coins
-food 1000
+slaying money
+food 10000
 x 26
 y 29
 connected 85
@@ -4607,7 +4622,8 @@ y 10
 end
 arch goldfloor
 name drop 125 gold coins
-food 125
+slaying money
+food 1250
 x 27
 y 10
 connected 88
@@ -4921,7 +4937,8 @@ y 4
 end
 arch goldfloor
 name drop 64 gold coins
-food 64
+slaying money
+food 640
 x 29
 y 4
 connected 89
@@ -5136,7 +5153,8 @@ y 16
 end
 arch goldfloor
 name drop 250 gold coins
-food 250
+slaying money
+food 2500
 x 30
 y 16
 connected 87

--- a/maps/darcap/darcap/circus/ghost
+++ b/maps/darcap/darcap/circus/ghost
@@ -7,7 +7,7 @@ width 32
 height 16
 msg
 Created:  1999-01-28 Cater & Wade (john_cater@yahoo.com)
-Modified: 2020-08-23 Acer
+Modified: 2020-09-04 Fauzin
 endmsg
 end
 arch dungeon_floor
@@ -376,7 +376,7 @@ arch dirtfloor
 x 2
 y 15
 end
-arch exit
+arch invis_exit
 slaying /world/world_116_102
 hp 35
 sp 13
@@ -3855,7 +3855,7 @@ arch dirtfloor
 x 27
 y 15
 end
-arch exit
+arch invis_exit
 slaying /world/world_116_102
 hp 37
 sp 13

--- a/maps/darcap/darcap/circus/ghost
+++ b/maps/darcap/darcap/circus/ghost
@@ -363,7 +363,8 @@ y 13
 end
 arch goldfloor
 name drop 30 gold coins
-food 30
+slaying money
+food 300
 x 2
 y 13
 connected 96

--- a/maps/darcap/darcap/circus/illusions
+++ b/maps/darcap/darcap/circus/illusions
@@ -8,7 +8,7 @@ enter_x 18
 enter_y 11
 msg
 Created:  1999-01-28 Cater & Wade (john_cater@yahoo.com)
-Modified: 2020-08-23 Acer
+Modified: 2020-09-04 Fauzin
 endmsg
 end
 arch small_stones
@@ -5252,7 +5252,8 @@ y 10
 end
 arch goldfloor
 name drop 20 gold coins
-food 20
+slaying money
+food 200
 x 16
 y 10
 connected 96
@@ -5267,7 +5268,8 @@ y 11
 end
 arch goldfloor
 name drop 20 gold coins
-food 20
+slaying money
+food 200
 x 16
 y 11
 connected 96
@@ -5282,7 +5284,8 @@ y 12
 end
 arch goldfloor
 name drop 20 gold coins
-food 20
+slaying money
+food 200
 x 16
 y 12
 connected 96
@@ -5297,7 +5300,8 @@ y 13
 end
 arch goldfloor
 name drop 20 gold coins
-food 20
+slaying money
+food 200
 x 16
 y 13
 connected 96
@@ -5468,7 +5472,8 @@ y 35
 end
 arch goldfloor
 name drop 20 gold coins
-food 20
+slaying money
+food 200
 x 16
 y 35
 connected 96
@@ -5483,7 +5488,8 @@ y 36
 end
 arch goldfloor
 name drop 20 gold coins
-food 20
+slaying money
+food 200
 x 16
 y 36
 connected 96
@@ -5498,7 +5504,8 @@ y 37
 end
 arch goldfloor
 name drop 20 gold coins
-food 20
+slaying money
+food 200
 x 16
 y 37
 connected 96
@@ -5513,7 +5520,8 @@ y 38
 end
 arch goldfloor
 name drop 20 gold coins
-food 20
+slaying money
+food 200
 x 16
 y 38
 connected 96
@@ -13378,7 +13386,8 @@ y 10
 end
 arch goldfloor
 name drop 20 gold coins
-food 20
+slaying money
+food 200
 x 41
 y 10
 connected 96
@@ -13393,7 +13402,8 @@ y 11
 end
 arch goldfloor
 name drop 20 gold coins
-food 20
+slaying money
+food 200
 x 41
 y 11
 connected 96
@@ -13408,7 +13418,8 @@ y 12
 end
 arch goldfloor
 name drop 20 gold coins
-food 20
+slaying money
+food 200
 x 41
 y 12
 connected 96
@@ -13423,7 +13434,8 @@ y 13
 end
 arch goldfloor
 name drop 20 gold coins
-food 20
+slaying money
+food 200
 x 41
 y 13
 connected 96
@@ -13594,7 +13606,8 @@ y 35
 end
 arch goldfloor
 name drop 20 gold coins
-food 20
+slaying money
+food 200
 x 41
 y 35
 connected 96
@@ -13609,7 +13622,8 @@ y 36
 end
 arch goldfloor
 name drop 20 gold coins
-food 20
+slaying money
+food 200
 x 41
 y 36
 connected 96
@@ -13624,7 +13638,8 @@ y 37
 end
 arch goldfloor
 name drop 20 gold coins
-food 20
+slaying money
+food 200
 x 41
 y 37
 connected 96
@@ -13639,7 +13654,8 @@ y 38
 end
 arch goldfloor
 name drop 20 gold coins
-food 20
+slaying money
+food 200
 x 41
 y 38
 connected 96

--- a/maps/darcap/darcap/circus/roller1
+++ b/maps/darcap/darcap/circus/roller1
@@ -6,7 +6,7 @@ width 16
 height 8
 msg
 Created:  1999-01-29 Cater & Wade & Fouras (john_cater@yahoo.com)
-Modified: 2020-08-23 Acer
+Modified: 2020-09-04 Fauzin
 endmsg
 end
 arch pstone_1
@@ -265,7 +265,8 @@ y 1
 end
 arch goldfloor
 name drop 20 gold coins
-food 20
+slaying money
+food 200
 x 4
 y 1
 connected 96
@@ -280,7 +281,8 @@ y 2
 end
 arch goldfloor
 name drop 20 gold coins
-food 20
+slaying money
+food 200
 x 4
 y 2
 connected 96
@@ -295,7 +297,8 @@ y 3
 end
 arch goldfloor
 name drop 20 gold coins
-food 20
+slaying money
+food 200
 x 4
 y 3
 connected 96
@@ -310,7 +313,8 @@ y 4
 end
 arch goldfloor
 name drop 20 gold coins
-food 20
+slaying money
+food 200
 x 4
 y 4
 connected 96

--- a/maps/darcap/darcap/circus/shooting
+++ b/maps/darcap/darcap/circus/shooting
@@ -3,7 +3,7 @@ name Darcap Circus Shooting Gallery
 difficulty 1
 region darcapcircus
 shopitems bow:100;arrow:100;*:-100
-shopgreed 1.40000
+shopgreed 1,40000
 shopmax 4000
 width 20
 height 16
@@ -2090,7 +2090,8 @@ y 6
 end
 arch goldfloor
 name drop 20 gold coins
-food 20
+slaying money
+food 200
 x 13
 y 6
 connected 96
@@ -2109,7 +2110,8 @@ y 7
 end
 arch goldfloor
 name drop 20 gold coins
-food 20
+slaying money
+food 200
 x 13
 y 7
 connected 96
@@ -2128,7 +2130,8 @@ y 8
 end
 arch goldfloor
 name drop 20 gold coins
-food 20
+slaying money
+food 200
 x 13
 y 8
 connected 96
@@ -2147,7 +2150,8 @@ y 9
 end
 arch goldfloor
 name drop 20 gold coins
-food 20
+slaying money
+food 200
 x 13
 y 9
 connected 96

--- a/maps/darcap/darcap/circus/shooting
+++ b/maps/darcap/darcap/circus/shooting
@@ -9,7 +9,7 @@ width 20
 height 16
 msg
 Created:  1999-01-28 Cater & Wade (john_cater@yahoo.com)
-Modified: 2020-08-23 Acer
+Modified: 2020-09-04 Fauzin
 endmsg
 end
 arch pstone_1
@@ -2472,7 +2472,7 @@ arch pstone_1
 x 15
 y 7
 end
-arch exit
+arch invis_exit
 slaying /world/world_116_102
 hp 34
 sp 14
@@ -2491,7 +2491,7 @@ arch pstone_1
 x 15
 y 8
 end
-arch exit
+arch invis_exit
 slaying /world/world_116_102
 hp 34
 sp 14

--- a/maps/darcap/darcap/circus/strength
+++ b/maps/darcap/darcap/circus/strength
@@ -6,7 +6,7 @@ width 20
 height 16
 msg
 Created:  1999-01-28 Cater & Wade (john_cater@yahoo.com)
-Modified: 2020-08-23 Acer
+Modified: 2020-09-04 Fauzin
 endmsg
 end
 arch pstone_1
@@ -1690,7 +1690,7 @@ arch pstone_1
 x 15
 y 7
 end
-arch exit
+arch invis_exit
 slaying /world/world_116_102
 hp 34
 sp 18
@@ -1701,7 +1701,7 @@ arch pstone_1
 x 15
 y 8
 end
-arch exit
+arch invis_exit
 slaying /world/world_116_102
 hp 34
 sp 18

--- a/maps/darcap/darcap/circus/strength
+++ b/maps/darcap/darcap/circus/strength
@@ -1458,7 +1458,8 @@ y 6
 end
 arch goldfloor
 name drop 20 gold coins
-food 20
+slaying money
+food 200
 x 13
 y 6
 connected 96
@@ -1469,7 +1470,8 @@ y 7
 end
 arch goldfloor
 name drop 20 gold coins
-food 20
+slaying money
+food 200
 x 13
 y 7
 connected 96
@@ -1480,7 +1482,8 @@ y 8
 end
 arch goldfloor
 name drop 20 gold coins
-food 20
+slaying money
+food 200
 x 13
 y 8
 connected 96
@@ -1491,7 +1494,8 @@ y 9
 end
 arch goldfloor
 name drop 20 gold coins
-food 20
+slaying money
+food 200
 x 13
 y 9
 connected 96

--- a/maps/darcap/darcap/circus/wheel
+++ b/maps/darcap/darcap/circus/wheel
@@ -556,7 +556,8 @@ y 11
 end
 arch goldfloor
 name drop 20 gold coins
-food 20
+slaying money
+food 200
 x 6
 y 11
 connected 96
@@ -567,7 +568,8 @@ y 12
 end
 arch goldfloor
 name drop 20 gold coins
-food 20
+slaying money
+food 200
 x 6
 y 12
 connected 96
@@ -578,7 +580,8 @@ y 13
 end
 arch goldfloor
 name drop 20 gold coins
-food 20
+slaying money
+food 200
 x 6
 y 13
 connected 96
@@ -589,7 +592,8 @@ y 14
 end
 arch goldfloor
 name drop 20 gold coins
-food 20
+slaying money
+food 200
 x 6
 y 14
 connected 96

--- a/maps/darcap/darcap/circus/wheel
+++ b/maps/darcap/darcap/circus/wheel
@@ -6,7 +6,7 @@ width 20
 height 16
 msg
 Created:  1999-03-10 Cater & Wade (john_cater@yahoo.com)
-Modified: 2020-08-23 Acer
+Modified: 2020-09-04 Fauzin
 endmsg
 end
 arch pstone_1
@@ -354,7 +354,7 @@ arch pstone_1
 x 4
 y 12
 end
-arch exit
+arch invis_exit
 slaying /world/world_116_102
 hp 42
 sp 18
@@ -365,7 +365,7 @@ arch pstone_1
 x 4
 y 13
 end
-arch exit
+arch invis_exit
 slaying /world/world_116_102
 hp 42
 sp 18

--- a/maps/darcap/darcap/circus/wurfbude
+++ b/maps/darcap/darcap/circus/wurfbude
@@ -10,7 +10,7 @@ enter_x 8
 enter_y 24
 msg
 Created:  2002-04-02 Bernd Edler (edler@heydernet.de)
-Modified: 2020-08-23 Acer
+Modified: 2020-09-04 Fauzin
 endmsg
 end
 arch dungeon_magic
@@ -2979,14 +2979,18 @@ arch dungeon_magic
 x 8
 y 25
 end
+arch invis_exit
+slaying /world/world_116_102
+hp 38
+sp 13
+x 8
+y 25
+end
 arch woodfloor
 x 8
 y 25
 end
 arch oakdoor_2
-slaying /world/world_116_102
-hp 38
-sp 13
 x 8
 y 25
 end

--- a/maps/darcap/darcap/potionshop
+++ b/maps/darcap/darcap/potionshop
@@ -10,7 +10,7 @@ enter_x 4
 enter_y 17
 msg
 Created:  1996-05-02 bt (thomas@astro.psu.edu)
-Modified: 2020-02-24 Acer
+Modified: 2020-09-04 Fauzin
 endmsg
 outdoor 1
 end
@@ -2254,6 +2254,10 @@ end
 arch shop_empty
 x 16
 y 18
+end
+arch flagstone
+x 16
+y 19
 end
 arch wwall_2_1_2
 x 16

--- a/maps/darcap/darcap/shop_g
+++ b/maps/darcap/darcap/shop_g
@@ -10,7 +10,7 @@ height 20
 enter_x 16
 enter_y 15
 msg
-Modified: 2012-01-29 Rick Tanner
+Modified: 2020-09-04 Fauzin
 endmsg
 outdoor 1
 end
@@ -1588,8 +1588,8 @@ y 18
 end
 arch invis_exit
 slaying /world/world_116_102
-hp 26
-sp 44
+hp 25
+sp 43
 x 15
 y 18
 end
@@ -1733,8 +1733,8 @@ y 18
 end
 arch invis_exit
 slaying /world/world_116_102
-hp 26
-sp 44
+hp 25
+sp 43
 x 16
 y 18
 end
@@ -1878,8 +1878,8 @@ y 18
 end
 arch invis_exit
 slaying /world/world_116_102
-hp 26
-sp 44
+hp 25
+sp 43
 x 17
 y 18
 end

--- a/maps/darcap/forgotten_town/city
+++ b/maps/darcap/forgotten_town/city
@@ -6,7 +6,7 @@ height 34
 msg
 Creator: CF Java Map Editor
 Date:    7/17/2005
-Modified: 2019-03-13 Acer
+Modified: 2020-09-04 Fauzin
 endmsg
 end
 arch cobblestones2
@@ -4870,6 +4870,8 @@ y 12
 end
 arch inn
 slaying inn
+hp 9
+sp 13
 x 24
 y 12
 end
@@ -5002,6 +5004,8 @@ end
 arch dark_palace
 name Palace of forgotten Town
 slaying palace
+hp 9
+sp 18
 x 25
 y 2
 end

--- a/maps/darcap/forgotten_town/shops/general
+++ b/maps/darcap/forgotten_town/shops/general
@@ -1,17 +1,18 @@
 arch map
 name Generalshop
 region Forgotten Town
-msg
-Creator: Knut Ahlers
-Date:    7/21/2005
-endmsg
+shopitems light source:50;inorganic:20;*:0
+shopmin 500
+shopmax 60000
 width 15
 height 15
 enter_x 13
 enter_y 13
-shopitems light source:50;inorganic:20;*:0
-shopmin 500
-shopmax 60000
+msg
+Creator: Knut Ahlers
+Date:    7/21/2005
+Modified: 2020-09-04 Fauzin
+endmsg
 end
 arch stonefloor2
 end
@@ -850,24 +851,24 @@ arch wwall_2_1_2
 x 12
 end
 arch stonefloor2
-no_magic 1
-damned 1
 x 12
 y 1
+no_magic 1
+damned 1
 end
 arch merchant
 name angry merchant
-friendly 1
-stand_still 1
-sleep 1
 x 12
 y 1
+friendly 1
+sleep 1
+stand_still 1
 end
 arch stonefloor2
-no_magic 1
-damned 1
 x 12
 y 2
+no_magic 1
+damned 1
 end
 arch shop_floor
 x 12
@@ -947,21 +948,23 @@ x 13
 y 1
 end
 arch stonefloor2
-no_magic 1
-damned 1
 x 13
 y 1
+no_magic 1
+damned 1
 end
 arch stair_down_4
 slaying general2
+hp 13
+sp 1
 x 13
 y 1
 end
 arch stonefloor2
-no_magic 1
-damned 1
 x 13
 y 2
+no_magic 1
+damned 1
 end
 arch shop_empty
 x 13

--- a/maps/scorn/houses/house3.bas1
+++ b/maps/scorn/houses/house3.bas1
@@ -6,7 +6,7 @@ msg
 Creator: Huhanhi
 Created with :  CF Java Map Editor
 Date:    3/23/2005
-Modified: 2020-01-20 Acer
+Modified: 2020-09-04 Fauzin
 endmsg
 end
 arch dungeon_floor
@@ -948,9 +948,10 @@ end
 arch mouse
 x 5
 y 6
-arch blue_key
-slaying ratkey0001
-face bones4.111
+arch bones4
+name rodent skeleton
+name_pl rodent skeletons
+materialname organic
 end
 end
 arch flagstone

--- a/maps/wassar/dungeon/dungeon1-u2
+++ b/maps/wassar/dungeon/dungeon1-u2
@@ -5,7 +5,7 @@ darkness 3
 width 40
 height 42
 msg
-Modified: 2020-08-31 Acer
+Modified: 2020-09-04 Fauzin
 endmsg
 end
 arch lostlabfloor12
@@ -1524,13 +1524,11 @@ arch dun_2_2_4
 x 6
 y 7
 end
-arch cobblestones
-face lostlabfloor12.x11
+arch lostlabfloor12
 x 6
 y 8
 end
-arch cobblestones
-face lostlabfloor12.x11
+arch lostlabfloor12
 x 6
 y 9
 end
@@ -1543,13 +1541,11 @@ arch boulder
 x 6
 y 9
 end
-arch cobblestones
-face lostlabfloor12.x11
+arch lostlabfloor12
 x 6
 y 10
 end
-arch cobblestones
-face lostlabfloor12.x11
+arch lostlabfloor12
 x 6
 y 11
 end
@@ -1776,8 +1772,7 @@ arch dun_2_1_2
 x 7
 y 6
 end
-arch cobblestones
-face lostlabfloor12.x11
+arch lostlabfloor12
 x 7
 y 7
 end
@@ -1790,13 +1785,11 @@ arch boulder
 x 7
 y 7
 end
-arch cobblestones
-face lostlabfloor12.x11
+arch lostlabfloor12
 x 7
 y 8
 end
-arch cobblestones
-face lostlabfloor12.x11
+arch lostlabfloor12
 x 7
 y 9
 end
@@ -1804,18 +1797,15 @@ arch dun_1_4
 x 7
 y 9
 end
-arch cobblestones
-face lostlabfloor12.x11
+arch lostlabfloor12
 x 7
 y 10
 end
-arch cobblestones
-face lostlabfloor12.x11
+arch lostlabfloor12
 x 7
 y 11
 end
-arch cobblestones
-face lostlabfloor12.x11
+arch lostlabfloor12
 x 7
 y 12
 end
@@ -2039,13 +2029,11 @@ arch dun_2_2_4
 x 8
 y 6
 end
-arch cobblestones
-face lostlabfloor12.x11
+arch lostlabfloor12
 x 8
 y 7
 end
-arch cobblestones
-face lostlabfloor12.x11
+arch lostlabfloor12
 x 8
 y 8
 end
@@ -2053,8 +2041,7 @@ arch dun_1_1
 x 8
 y 8
 end
-arch cobblestones
-face lostlabfloor12.x11
+arch lostlabfloor12
 x 8
 y 9
 end
@@ -2062,8 +2049,7 @@ arch dun_4
 x 8
 y 9
 end
-arch cobblestones
-face lostlabfloor12.x11
+arch lostlabfloor12
 x 8
 y 10
 end
@@ -2071,8 +2057,7 @@ arch dun_2_2_1
 x 8
 y 10
 end
-arch cobblestones
-face lostlabfloor12.x11
+arch lostlabfloor12
 x 8
 y 11
 end
@@ -2085,8 +2070,7 @@ arch boulder
 x 8
 y 11
 end
-arch cobblestones
-face lostlabfloor12.x11
+arch lostlabfloor12
 x 8
 y 12
 end
@@ -2306,13 +2290,11 @@ arch dun_2_1_2
 x 9
 y 5
 end
-arch cobblestones
-face lostlabfloor12.x11
+arch lostlabfloor12
 x 9
 y 6
 end
-arch cobblestones
-face lostlabfloor12.x11
+arch lostlabfloor12
 x 9
 y 7
 end
@@ -2320,8 +2302,7 @@ arch boulder
 x 9
 y 7
 end
-arch cobblestones
-face lostlabfloor12.x11
+arch lostlabfloor12
 x 9
 y 8
 end
@@ -2330,8 +2311,7 @@ x 9
 y 8
 connected 13
 end
-arch cobblestones
-face lostlabfloor12.x11
+arch lostlabfloor12
 x 9
 y 9
 end
@@ -2339,8 +2319,7 @@ arch dun_3_3
 x 9
 y 9
 end
-arch cobblestones
-face lostlabfloor12.x11
+arch lostlabfloor12
 x 9
 y 10
 end
@@ -2348,8 +2327,7 @@ arch dun_3_4
 x 9
 y 10
 end
-arch cobblestones
-face lostlabfloor12.x11
+arch lostlabfloor12
 x 9
 y 11
 end
@@ -2357,13 +2335,11 @@ arch dun_2_2_1
 x 9
 y 11
 end
-arch cobblestones
-face lostlabfloor12.x11
+arch lostlabfloor12
 x 9
 y 12
 end
-arch cobblestones
-face lostlabfloor12.x11
+arch lostlabfloor12
 x 9
 y 13
 end
@@ -2627,13 +2603,11 @@ arch dun_3_1
 x 10
 y 5
 end
-arch cobblestones
-face lostlabfloor12.x11
+arch lostlabfloor12
 x 10
 y 6
 end
-arch cobblestones
-face lostlabfloor12.x11
+arch lostlabfloor12
 x 10
 y 7
 end
@@ -2641,13 +2615,11 @@ arch dun_0
 x 10
 y 7
 end
-arch cobblestones
-face lostlabfloor12.x11
+arch lostlabfloor12
 x 10
 y 8
 end
-arch cobblestones
-face lostlabfloor12.x11
+arch lostlabfloor12
 x 10
 y 9
 end
@@ -2655,8 +2627,7 @@ arch dun_2_1_2
 x 10
 y 9
 end
-arch cobblestones
-face lostlabfloor12.x11
+arch lostlabfloor12
 x 10
 y 10
 end
@@ -2665,8 +2636,7 @@ x 10
 y 10
 connected 18
 end
-arch cobblestones
-face lostlabfloor12.x11
+arch lostlabfloor12
 x 10
 y 11
 end
@@ -2674,8 +2644,7 @@ arch dun_2_1_2
 x 10
 y 11
 end
-arch cobblestones
-face lostlabfloor12.x11
+arch lostlabfloor12
 x 10
 y 12
 end
@@ -2900,13 +2869,11 @@ arch dun_2_1_2
 x 11
 y 5
 end
-arch cobblestones
-face lostlabfloor12.x11
+arch lostlabfloor12
 x 11
 y 6
 end
-arch cobblestones
-face lostlabfloor12.x11
+arch lostlabfloor12
 x 11
 y 7
 end
@@ -2918,8 +2885,7 @@ sp 7
 x 11
 y 7
 end
-arch cobblestones
-face lostlabfloor12.x11
+arch lostlabfloor12
 x 11
 y 8
 end
@@ -2927,8 +2893,7 @@ arch dun_1_1
 x 11
 y 8
 end
-arch cobblestones
-face lostlabfloor12.x11
+arch lostlabfloor12
 x 11
 y 9
 end
@@ -2936,8 +2901,7 @@ arch dun_2_2_4
 x 11
 y 9
 end
-arch cobblestones
-face lostlabfloor12.x11
+arch lostlabfloor12
 x 11
 y 10
 end
@@ -2945,8 +2909,7 @@ arch boulder
 x 11
 y 10
 end
-arch cobblestones
-face lostlabfloor12.x11
+arch lostlabfloor12
 x 11
 y 11
 end
@@ -2954,8 +2917,7 @@ arch dun_1_3
 x 11
 y 11
 end
-arch cobblestones
-face lostlabfloor12.x11
+arch lostlabfloor12
 x 11
 y 12
 end
@@ -3197,8 +3159,7 @@ arch dun_2_2_1
 x 12
 y 6
 end
-arch cobblestones
-face lostlabfloor12.x11
+arch lostlabfloor12
 x 12
 y 7
 end
@@ -3206,28 +3167,23 @@ arch boulder
 x 12
 y 7
 end
-arch cobblestones
-face lostlabfloor12.x11
+arch lostlabfloor12
 x 12
 y 8
 end
-arch cobblestones
-face lostlabfloor12.x11
+arch lostlabfloor12
 x 12
 y 9
 end
-arch cobblestones
-face lostlabfloor12.x11
+arch lostlabfloor12
 x 12
 y 10
 end
-arch cobblestones
-face lostlabfloor12.x11
+arch lostlabfloor12
 x 12
 y 11
 end
-arch cobblestones
-face lostlabfloor12.x11
+arch lostlabfloor12
 x 12
 y 12
 end
@@ -3461,13 +3417,11 @@ arch dun_2_2_4
 x 13
 y 6
 end
-arch cobblestones
-face lostlabfloor12.x11
+arch lostlabfloor12
 x 13
 y 7
 end
-arch cobblestones
-face lostlabfloor12.x11
+arch lostlabfloor12
 x 13
 y 8
 end
@@ -3728,8 +3682,7 @@ arch dun_2_1_2
 x 14
 y 5
 end
-arch cobblestones
-face lostlabfloor12.x11
+arch lostlabfloor12
 x 14
 y 6
 end
@@ -3738,13 +3691,11 @@ x 14
 y 6
 connected 11
 end
-arch cobblestones
-face lostlabfloor12.x11
+arch lostlabfloor12
 x 14
 y 7
 end
-arch cobblestones
-face lostlabfloor12.x11
+arch lostlabfloor12
 x 14
 y 8
 end
@@ -5046,7 +4997,7 @@ arch lostlabfloor12
 x 18
 y 29
 end
-arch stair3_jstone_do
+arch stair3_gstone_do
 slaying dungeon1-u2
 hp 29
 sp 26
@@ -5732,7 +5683,6 @@ arch sign
 msg
 Break the wall...
 endmsg
-face lostlabfloor12.111
 x 21
 y 10
 end
@@ -6522,7 +6472,6 @@ arch key2
 name I
 name_pl Is
 slaying wassar_dungeon1_room
-face glyph_I.111
 x 24
 y 7
 end
@@ -7261,7 +7210,6 @@ y 8
 end
 arch locked_door2
 slaying wassar_dungeon1_room
-face dun_5.x11
 x 27
 y 8
 end
@@ -7872,10 +7820,7 @@ arch cobbles_black
 x 29
 y 26
 end
-arch stair3_jstone_up
-slaying dungeon1-u2
-hp 18
-sp 29
+arch stair3_gstone_up
 x 29
 y 26
 end

--- a/maps/world/world_100_125
+++ b/maps/world/world_100_125
@@ -5,7 +5,7 @@ region aldwulf
 width 50
 height 50
 msg
-Modified: 2020-02-16 Acer
+Modified: 2020-09-04 Fauzin
 endmsg
 outdoor 1
 tile_path_1 world_100_124
@@ -5041,9 +5041,9 @@ x 12
 y 18
 end
 arch rowboat
-slaying smaug_island
-hp 10
-sp 9
+slaying /aldwulf/smaug_island
+hp 18
+sp 10
 x 12
 y 18
 end
@@ -5688,7 +5688,7 @@ end
 arch phole_2
 slaying /aldwulf/isles
 hp 19
-sp 45
+sp 12
 x 14
 y 33
 end

--- a/maps/world/world_104_115
+++ b/maps/world/world_104_115
@@ -12,7 +12,7 @@ Creator: Gnat the Gnu
 Email: gnu@foo.bar
 Date: Sun Dec 16 20:41:49 2001
 arch
-Modified: 2020-08-28 Acer
+Modified: 2020-09-04 Fauzin
 endmsg
 outdoor 1
 tile_path_1 world_104_114
@@ -8341,6 +8341,10 @@ arch grass
 x 26
 y 34
 end
+arch tree4
+x 26
+y 34
+end
 arch magic_banned
 x 26
 y 35
@@ -8350,10 +8354,6 @@ x 26
 y 35
 end
 arch grass
-x 26
-y 35
-end
-arch tree4
 x 26
 y 35
 end
@@ -12970,7 +12970,7 @@ arch grass
 x 37
 y 31
 end
-arch store_general
+arch store_gems
 name Gem Shop
 slaying /scorn/shops/gemshop
 hp 1

--- a/maps/world/world_116_102
+++ b/maps/world/world_116_102
@@ -10572,7 +10572,7 @@ arch hut
 name Throwing Gallery
 slaying /darcap/darcap/circus/wurfbude
 hp 8
-sp 25
+sp 24
 x 38
 y 12
 end

--- a/maps/world/world_116_102
+++ b/maps/world/world_116_102
@@ -5,7 +5,7 @@ region darcap
 width 50
 height 50
 msg
-Modified: 2020-08-23 Acer
+Modified: 2020-09-04 Fauzin
 endmsg
 outdoor 1
 tile_path_1 world_116_101
@@ -5180,7 +5180,7 @@ name Spike's Weapons
 name_pl Spike's Weapons
 slaying /darcap/darcap/shop_w
 hp 10
-sp 17
+sp 16
 x 19
 y 37
 end
@@ -5225,7 +5225,7 @@ name Mirkland's Magic
 name_pl Mirkland's Magic
 slaying /darcap/darcap/shop_m
 hp 10
-sp 27
+sp 26
 x 19
 y 43
 end
@@ -6261,8 +6261,8 @@ end
 arch t_house1
 name General Shop
 slaying /darcap/darcap/gshop
-hp 15
-sp 6
+hp 18
+sp 17
 x 23
 y 25
 end
@@ -6879,8 +6879,8 @@ arch store_armour
 name Smith's Armors
 name_pl Smith's Armors
 slaying /darcap/darcap/shop_a
-hp 1
-sp 14
+hp 4
+sp 16
 x 25
 y 37
 end
@@ -7179,9 +7179,9 @@ end
 arch house_2
 name Fire House
 name_pl Fire House
-slaying /darcap/darcap/houses
-hp 8
-sp 1
+slaying /darcap/darcap/firehouse
+hp 7
+sp 7
 x 26
 y 33
 end
@@ -7226,7 +7226,7 @@ name Gaea's Garden
 name_pl Gaea's Garden
 slaying /darcap/darcap/temple
 hp 12
-sp 23
+sp 22
 x 26
 y 41
 end
@@ -7494,9 +7494,9 @@ end
 arch house_2
 name Water House
 name_pl Water House
-slaying /darcap/darcap/houses
-hp 24
-sp 1
+slaying /darcap/darcap/waterhouse
+hp 3
+sp 7
 x 27
 y 33
 end
@@ -7742,8 +7742,8 @@ y 25
 end
 arch store_alchemy
 slaying /darcap/darcap/potionshop
-hp 14
-sp 14
+hp 4
+sp 18
 x 28
 y 25
 end
@@ -7791,9 +7791,9 @@ end
 arch house_2
 name Air House
 name_pl Air House
-slaying /darcap/darcap/houses
-hp 8
-sp 31
+slaying /darcap/darcap/airhouse
+hp 6
+sp 7
 x 28
 y 33
 end
@@ -8089,9 +8089,9 @@ end
 arch house_2
 name Earth House
 name_pl Earth House
-slaying /darcap/darcap/houses
-hp 24
-sp 31
+slaying /darcap/darcap/earthhouse
+hp 2
+sp 7
 x 29
 y 33
 end


### PR DESCRIPTION
This PR contains various different fixes. I seperated them to the best of my ability into logical commits.

Notes for commit 9c8b63a "Accept any currency in darcap circus":

- If gold specifically being used is wanted, this commit can be removed. I wanted to improve convenience.
- The map "/darcap/darcap/circus/double" should definitely be checked ingame. The editor shows a warning because food isn't between 1 and 32767 for three of the goldfloors. On the server the value is stored as an "int32_t" and should be able to hold positive integers up to 2147483647.  Sadly I cannot test the behaviour myself at the moment.