### PR TITLE
Add private transports and some related functionality

### DIFF
--- a/maps/.gitignore
+++ b/maps/.gitignore
@@ -1,1 +1,12 @@
 *.pyc
+
+# ignore world_built/ files, but not its directories
+# use READMEs
+world_built/*/*
+!world_built/*/README
+!world_built/*/.gitkeep
+
+# ignore cabin found at ship-cabins/
+ship-cabins/cabin-*
+ship-cabins/ship-serial.txt
+!ship-cabins/cabin-template

--- a/maps/python/events/free_objects/debug.py
+++ b/maps/python/events/free_objects/debug.py
@@ -1,0 +1,7 @@
+import Crossfire
+
+import utils
+
+
+map_ = Crossfire.WhoAmI()
+utils.log_debug('%s %s' % ('free_objects', map_.Path))

--- a/maps/python/events/free_objects/hook_tracking_system.py
+++ b/maps/python/events/free_objects/hook_tracking_system.py
@@ -1,0 +1,9 @@
+"""Hook for the tracking system"""
+
+import Crossfire
+
+import tracking_system
+
+
+map_ = Crossfire.WhoAmI()
+tracking_system.hook_freeobjects(map_)

--- a/maps/python/events/mapload/debug.py
+++ b/maps/python/events/mapload/debug.py
@@ -1,0 +1,7 @@
+import Crossfire
+
+import utils
+
+
+map_ = Crossfire.WhoAmI()
+utils.log_debug('%s %s' % ('mapload', map_.Path))

--- a/maps/python/events/mapload/hook_tracking_system.py
+++ b/maps/python/events/mapload/hook_tracking_system.py
@@ -1,0 +1,9 @@
+"""Hook for the tracking system"""
+
+import Crossfire
+
+import tracking_system
+
+
+map_ = Crossfire.WhoAmI()
+tracking_system.hook_mapload(map_)

--- a/maps/python/events/mapreset/debug.py
+++ b/maps/python/events/mapreset/debug.py
@@ -1,0 +1,7 @@
+import Crossfire
+
+import utils
+
+
+map_ = Crossfire.WhoAmI()
+utils.log_debug('%s %s' % ('mapreset', map_.Path))

--- a/maps/python/events/mapreset/hook_tracking_system.py
+++ b/maps/python/events/mapreset/hook_tracking_system.py
@@ -1,0 +1,9 @@
+"""Hook for the tracking system"""
+
+import Crossfire
+
+import tracking_system
+
+
+map_ = Crossfire.WhoAmI()
+tracking_system.hook_freeobjects(map_)

--- a/maps/python/events/mapunload/debug.py
+++ b/maps/python/events/mapunload/debug.py
@@ -1,0 +1,7 @@
+import Crossfire
+
+import utils
+
+
+map_ = Crossfire.WhoAmI()
+utils.log_debug('%s %s' % ('mapunload', map_.Path))

--- a/maps/python/events/mapunload/hook_tracking_system.py
+++ b/maps/python/events/mapunload/hook_tracking_system.py
@@ -1,0 +1,9 @@
+"""Hook for the tracking system"""
+
+import Crossfire
+
+import tracking_system
+
+
+map_ = Crossfire.WhoAmI()
+tracking_system.hook_freeobjects(map_)

--- a/maps/python/events/server_shutdown/hook_tracking_system.py
+++ b/maps/python/events/server_shutdown/hook_tracking_system.py
@@ -1,0 +1,15 @@
+"""Hook for the tracking system
+
+When the server shuts down, all maps are unloaded.
+
+This script calls the free_objects hook on all maps that are currently
+loaded when the server goes down.
+"""
+
+import Crossfire
+
+import tracking_system
+
+
+for map_ in Crossfire.GetMaps():
+    tracking_system.hook_freeobjects(map_)

--- a/maps/python/private_ship/README.txt
+++ b/maps/python/private_ship/README.txt
@@ -1,0 +1,25 @@
+# Private transport
+
+A private transport is a transport you can make yours.
+
+I think I'll be using the word "personal" when facing the players (a
+"personal ship" sounds a bit more pleasant than a "private ship")
+
+
+# Features of private transports
+
+Private transports come featureless.
+
+You can buy scrolls, like the "Add Cabin To Ship", to add new features to
+your transport.
+
+
+# History of Name
+
+This section was originally named "Private Ships" (therefore the name of
+the directory). However, as the feature may be used by more objects than
+just ships (for example, you can have personal dragons or personal
+ships), I decided to rename it to "Private Transports".
+
+private_ship is still the name of the directory because I don't want to
+break anything.

--- a/maps/python/private_ship/__init__.py
+++ b/maps/python/private_ship/__init__.py
@@ -1,0 +1,2 @@
+# This file is needed so this directory is recognized as a package and
+# the imports work!

--- a/maps/python/private_ship/add_anchor.py
+++ b/maps/python/private_ship/add_anchor.py
@@ -1,0 +1,158 @@
+"""
+Script called when an "Add anchor" scroll is used
+"""
+
+import Crossfire
+from private_ship.common import ActionError
+from private_ship.common import InternalError
+from private_ship.common import check_if_player_inside_private_transport_they_own
+from private_ship.common import generate_feature_id
+from private_ship.common import get_player_transport
+from private_ship.common import get_private_transport_feature_type
+from private_ship.common import set_private_transport_feature_flag
+from private_ship.common import set_private_transport_feature_id
+from private_ship.common import set_private_transport_feature_type
+from private_ship.config import ANCHOR_ARCHETYPE
+from private_ship.config import ANCHOR_KEY_ARCHETYPE
+from private_ship.config import ANCHOR_KEY_GENERATED_COUNT
+from private_ship.config import ANCHOR_KEY_NAME
+from private_ship.config import ANCHOR_KEY_NAME_PL
+from private_ship.config import ANCHOR_NAME
+from private_ship.config import FEATURE_KEY_SLAYING_PREFIX
+from private_ship.config import PLAYER_MESSAGES
+from private_ship.utils import send_error_to_player
+from private_ship.utils import send_info_to_player
+from utils import iter_inv
+from utils import log_error
+
+
+# Exceptions
+#
+# pylint: disable=missing-class-docstring
+
+class CanOnlyHaveOneAnchor(ActionError):
+    msg = PLAYER_MESSAGES['can_only_have_one_anchor']
+
+
+# Logic
+
+# (player applies "Add anchor" scroll)
+# if player can create an anchor
+  # create anchor
+  # add it to private transport inventory
+# otherwise
+  # inform the player and exit
+
+def main():
+    """Main script"""
+
+    player = Crossfire.WhoIsActivator()
+    scroll = Crossfire.WhoAmI()
+
+    try:
+        check_if_player_can_use_scroll(player, scroll)
+        use_scroll(player, scroll)
+    # TODO: this error handling could be common
+    except InternalError as err:
+        log_error(err.errmsg)
+        send_error_to_player(err.msg, player)
+        return
+    except ActionError as err:
+        send_error_to_player(err.msg, player)
+        return
+    except Exception as err:
+        send_error_to_player(InternalError.msg, player)
+        raise
+
+
+def check_if_player_can_use_scroll(player, scroll):
+    """Verify if player can use scroll
+
+    If player can't use scroll, raise an ActionError.
+    """
+
+    # player must be inside a private transport they own
+    check_if_player_inside_private_transport_they_own(player)
+
+    # there can only be 1 anchor per ship
+    transport = get_player_transport(player)
+    num_anchors = get_number_of_anchors(transport)
+    if num_anchors >= 1:
+        raise CanOnlyHaveOneAnchor
+
+    # everything fine
+
+
+def use_scroll(player, scroll):
+    """Use the "Add anchor" scroll"""
+
+    # Generate anchor id
+    id_ = generate_feature_id()
+
+    # Create andhor and add it to the transport's inventory
+    create_anchor(player, scroll, id_)
+
+    # Create keys and add them to player's inventory
+    create_anchor_keys(player, scroll, id_)
+
+    # Inform the player
+    send_info_to_player(
+        PLAYER_MESSAGES['anchor_added'],
+        player,
+    )
+
+    # Remove the scroll
+    scroll.Quantity -= 1
+
+    # Get player out and into transport mode to display the new feature
+    transport = get_player_transport(player)
+    transport.Apply(player, 0)
+    transport.Apply(player, 0)
+
+
+def get_number_of_anchors(transport):
+    """Get the number of anchors in a private transport"""
+    return sum(is_anchor(obj) for obj in iter_inv(transport))
+
+
+def is_anchor(obj):
+    """Check if object_ is an anchor"""
+    return get_private_transport_feature_type(obj) == 'anchor'
+
+
+def create_anchor(player, scroll, id_):
+    """Create an anchor with a certain id_
+
+    Returns:
+        A reference to the newly created anchor object.
+    """
+
+    transport = get_player_transport(player)
+
+    # Create anchor
+    anchor = transport.CreateObject(ANCHOR_ARCHETYPE)
+    set_private_transport_feature_flag(anchor)
+    set_private_transport_feature_type(anchor, 'anchor')
+    set_private_transport_feature_id(anchor, id_)
+
+    # Set anchor name (so we can match it with key)
+    anchor.Name = ANCHOR_NAME.format(id_=id_)
+    anchor.NamePl = ANCHOR_NAME.format(id_=id_)
+
+    return anchor
+
+
+def create_anchor_keys(player, scroll, id_):
+    """Create keys for an anchor with ID id_"""
+
+    keys = player.CreateObject(ANCHOR_KEY_ARCHETYPE)
+    keys.Slaying = FEATURE_KEY_SLAYING_PREFIX + id_
+    keys.Quantity = ANCHOR_KEY_GENERATED_COUNT
+    keys.Name = ANCHOR_KEY_NAME.format(id_=id_)
+    keys.NamePl = ANCHOR_KEY_NAME_PL.format(id_=id_)
+
+
+# prevent scroll apply
+Crossfire.SetReturnValue(1)
+
+main()

--- a/maps/python/private_ship/anchor.py
+++ b/maps/python/private_ship/anchor.py
@@ -1,0 +1,121 @@
+"""
+Script run when a private ship anchor is applied.
+"""
+
+import Crossfire
+
+from private_ship.common import ActionError
+from private_ship.common import InternalError
+from private_ship.common import check_if_player_can_use_feature
+from private_ship.common import get_player_transport
+from private_ship.config import PLAYER_MESSAGES
+from private_ship.config import PRIVATE_TRANSPORT_ATTRS
+from private_ship.utils import send_error_to_player
+from private_ship.utils import send_info_to_player
+from utils import log_error
+
+
+
+# (player applies anchor)
+# check if player can use feature (common)
+#   if not, inform the user and exit
+# If player can use feature
+#   toggle anchored status of private ship
+#     > private_transport_anchored
+#   set speed accordingly
+#     > private_transport_base_speed
+#     > speed
+
+def main():
+    """Main script"""
+
+    player = Crossfire.WhoIsActivator()
+    anchor = Crossfire.WhoAmI()
+
+    try:
+        check_if_player_can_use_anchor(player, anchor)
+        use_anchor(player, anchor)
+    except InternalError as err:
+        log_error(err.errmsg)
+        send_error_to_player(err.msg, player)
+        return
+    except ActionError as err:
+        send_error_to_player(err.msg, player)
+        return
+    except Exception:
+        send_error_to_player(InternalError.msg, player)
+        raise
+
+
+def check_if_player_can_use_anchor(player, anchor):
+    """Verify if player can use anchor
+
+    If player can't use, raise an ActionError, otherwise, NOOP.
+    """
+    check_if_player_can_use_feature(player, anchor)
+
+
+def use_anchor(player, anchor):
+    """Use an anchor"""
+
+    transport = get_player_transport(player)
+    toggle_anchored(player, transport, anchor)
+
+
+def toggle_anchored(player, transport, anchor):
+    """Toggle anchored status of a transport"""
+
+    if is_transport_anchored(transport):
+        deactivate_anchor(player, transport, anchor)
+    else:
+        activate_anchor(player, transport, anchor)
+
+
+def activate_anchor(player, transport, anchor):
+    """Activate the anchor of a ship"""
+    # set anchored state
+    transport.WriteKey(PRIVATE_TRANSPORT_ATTRS['anchored'], '1', 1)
+    # set speed to 0
+    transport.Speed = 0.
+    # I don't know the reason, but, when Speed is set to 0, the
+    # transport can still move one tile. Setting SpeedLeft to a negative
+    # value stops this from happening.
+    transport.SpeedLeft = -0.01
+    # notify the user that an anchor is being used
+    send_info_to_player(
+        PLAYER_MESSAGES['transport_anchor_activated'],
+        player,
+    )
+
+
+def deactivate_anchor(player, transport, anchor):
+    """Deactivate anchor of a ship"""
+    # set anchored state
+    transport.WriteKey(PRIVATE_TRANSPORT_ATTRS['anchored'], '0', 1)
+    # set speed as base speed
+    try:
+        base_speed = float(transport.ReadKey(PRIVATE_TRANSPORT_ATTRS['base_speed']))
+    except ValueError:
+        send_error_to_player("There was a problem while deactivating the anchor of "
+                             "your ship. It may become slower than usual, "
+                             "a DM may help you with it.", player)
+        log_error("%s is using an anchor on a private transport without base speed. "
+                  "Setting transport speed to 0.5." % player.Name)
+        base_speed = 0.5
+    transport.Speed = base_speed
+    # notify the user that the anchor is lifted
+    send_info_to_player(
+        PLAYER_MESSAGES['transport_anchor_deactivated'],
+        player,
+    )
+
+
+def is_transport_anchored(transport):
+    """Return True if transport is anchored, False otherwise"""
+    return transport.ReadKey(PRIVATE_TRANSPORT_ATTRS['anchored']) == '1'
+
+
+# prevent anchor usage
+Crossfire.SetReturnValue(1)
+
+main()

--- a/maps/python/private_ship/common.py
+++ b/maps/python/private_ship/common.py
@@ -1,0 +1,227 @@
+"""
+Common functions for the private transport
+"""
+
+import private_ship.idgen as idgen
+from private_ship.config import FEATURE_KEY_SLAYING_PREFIX
+from private_ship.config import PLAYER_MESSAGES
+from private_ship.config import PRIVATE_TRANSPORT_ATTRS
+from private_ship.config import PRIVATE_TRANSPORT_FEATURE_ATTRS
+
+
+# Exceptions
+#
+# pylint: disable=missing-class-docstring
+
+class ActionError(Exception):
+    """Error that occurs when the player cannot execute an action
+
+    Raise me when the player cannot execute the action he wants!
+
+    Raising me should stop the script from running and send an error
+    message to the player.
+
+    Attributes:
+        msg: A message that will be displayed to the player.
+    """
+    msg = PLAYER_MESSAGES['action_error_basic']
+
+
+class InternalError(ActionError):
+    """User cannot execute action but because something happened on the
+    server side!
+    """
+    msg = PLAYER_MESSAGES['internal_error']
+
+    def __init__(self, error_message):
+        """Initialize an internal error
+
+        Args:
+            error_message: A message to log to the server when this
+            error occurs.
+        """
+        super(InternalError, self).__init__()
+        self.errmsg = error_message
+
+
+class PlayerNotInsideTransport(ActionError):
+    msg = PLAYER_MESSAGES['player_not_inside_transport']
+
+
+class PlayerInsidePublicTransport(ActionError):
+    msg = PLAYER_MESSAGES['player_inside_public_transport']
+
+
+class NotOwnerOfTheTransport(ActionError):
+    msg = PLAYER_MESSAGES['not_owner_of_transport']
+
+
+class TransportHasNoOwner(NotOwnerOfTheTransport):
+    msg = PLAYER_MESSAGES['transport_has_no_owner']
+
+
+class TransportOwnedBySomeoneElse(NotOwnerOfTheTransport):
+    msg = PLAYER_MESSAGES['transport_owned_by_someone_else']
+
+
+class PlayerCannotUseFeature(ActionError):
+    msg = PLAYER_MESSAGES['player_cannot_use_feature']
+
+
+# Utilities
+
+def check_if_player_inside_transport(player):
+    """Verify if player is inside a transport."""
+
+    transport = get_player_transport(player)
+    if not transport:
+        raise PlayerNotInsideTransport
+
+
+def check_if_player_inside_private_transport(player):
+    """Verify if player is inside a private transport."""
+
+    check_if_player_inside_transport(player)
+
+    transport = get_player_transport(player)
+    if not is_private_transport(transport):
+        raise PlayerInsidePublicTransport
+
+
+def check_if_player_inside_private_transport_they_own(player):
+    """Verify if player is inside a private transport they own."""
+
+    check_if_player_inside_private_transport(player)
+
+    transport = get_player_transport(player)
+    if not is_transport_owned_by_player(transport, player):
+        raise NotOwnerOfTheTransport
+
+
+def check_if_player_inside_private_transport_they_own_or_can_own(player):
+    """Verify if player is inside a private transport they own or can
+    own (ownerless).
+
+    NOP if the transport is ownerless or if the player already owns the
+    transport.
+    """
+
+    check_if_player_inside_private_transport(player)
+
+    transport = get_player_transport(player)
+    if (is_transport_owned(transport) and
+            not is_transport_owned_by_player(transport, player)):
+        raise TransportOwnedBySomeoneElse
+
+
+def check_if_player_can_use_feature(player, feature):
+    """Verify if player can use a private transport feature
+
+    They will be allowed in two conditions:
+
+    - They are the owner of the transport
+    - They have a key to use the feature
+    """
+
+    transport = get_player_transport(player)
+
+    if (not is_transport_owned_by_player(transport, player) and
+            not does_player_have_feature_key(player, feature)):
+        raise PlayerCannotUseFeature
+
+
+def does_player_have_feature_key(player, feature):
+    """Return whether the player has a key to the feature.
+
+    Objects:
+
+    - feature:
+          id
+    - key:
+          slaying (linked to feature id)
+    """
+
+    id_ = feature.ReadKey(PRIVATE_TRANSPORT_FEATURE_ATTRS['id'])
+    assert id_ != ''
+    slaying = FEATURE_KEY_SLAYING_PREFIX + id_
+    return player.CheckInventory(slaying) is not None
+
+
+def get_player_transport(player):
+    """Return the transport the player is in, or None, if player is not
+    insed a transport."""
+    # This actually returns anything the player is inside
+    return player.Env
+
+
+def is_private_transport(transport):
+    """Return whether transport is a private transport or not
+    """
+    return transport.ReadKey(PRIVATE_TRANSPORT_ATTRS['flag']) == '1'
+
+
+def is_transport_owned(transport):
+    """Return whether a private transport is owned or not
+    """
+    return get_transport_owner_name(transport) is not None
+
+
+def is_transport_owned_by_player(transport, player):
+    """Check if a transport is owned by a player"""
+    return get_transport_owner_name(transport) == player.Name
+
+
+def get_transport_owner_name(transport):
+    """Return the name of the transport owner or None, if none"""
+    return transport.ReadKey(PRIVATE_TRANSPORT_ATTRS['owner_name']) or None
+
+
+def get_private_transport_feature_type(feature):
+    """Get the type of feature an object is.
+
+    If the object is not a feature, return ''.
+    """
+    if not is_private_transport_feature(feature):
+        return ''
+    return feature.ReadKey(PRIVATE_TRANSPORT_FEATURE_ATTRS['type'])
+
+
+def set_private_transport_feature_flag(feature, value='1'):
+    """Set the private transport feature flag for this object
+
+    '1' indicates a private transport feature
+    '0' or '' indicates not a feature
+
+    Default value indicates to set as a feature.
+    """
+    feature.WriteKey(PRIVATE_TRANSPORT_FEATURE_ATTRS['flag'], value, 1)
+
+
+def set_private_transport_feature_id(feature, id_):
+    """Set the id of this feature"""
+    feature.WriteKey(PRIVATE_TRANSPORT_FEATURE_ATTRS['id'], id_, 1)
+
+
+def set_private_transport_feature_type(feature, type_):
+    """Set the type of feature this object is.
+
+    Args:
+        feature
+        type_ (str)
+    """
+    feature.WriteKey(PRIVATE_TRANSPORT_FEATURE_ATTRS['type'], type_, 1)
+
+
+def is_private_transport_feature(obj):
+    """Return whether an object is a private transport feature"""
+    return obj.ReadKey(PRIVATE_TRANSPORT_FEATURE_ATTRS['flag']) == '1'
+
+
+def generate_feature_id():
+    """Generate a unique ID for a feature
+
+    Returns:
+        (str) A unique ID for a private ship feature. This is guaranteed
+        to be unique across all private ship features.
+    """
+    return idgen.generate()

--- a/maps/python/private_ship/config.py
+++ b/maps/python/private_ship/config.py
@@ -1,0 +1,121 @@
+"""
+Configuration for the private ship scripts !
+"""
+
+import Crossfire
+
+import private_ship.path as path
+
+
+ERROR_MESSAGE_FLAGS = Crossfire.MessageFlag.NDI_UNIQUE
+INFORMATION_MESSAGE_FLAGS = Crossfire.MessageFlag.NDI_UNIQUE
+
+
+# Messages for the player
+# DO NOT MODIFY THE KEY of the messages (but the content is okay)
+PLAYER_MESSAGES = {
+
+    # Error Messages
+
+    'action_error_basic': "Sorry, cannot do that.",
+    'internal_error': "Sorry, cannot do that. Contact a DM if you keep having this problem.",
+    'scroll_not_renamed': "You must rename the scroll before applying it to the ship.",
+    'player_not_inside_transport': "Cannot do this outside of a transport.",
+    'player_inside_public_transport': "Use a personal transport!",
+    'not_owner_of_transport': "You are not owner of this ship!",
+    'transport_has_no_owner': "You are not owner of this ship!",
+    'transport_owned_by_someone_else': "You are not the owner of this ship!",
+    'cannot_create_more_cabins': "Sorry, you can't add more cabins to this ship.",
+    'player_cannot_use_feature': "You must be the owned of this ship or have a key, to try that.",
+    'lost_track_of_transport': "Sorry, we lost track of your transport. We will be teleporting you to your bed, instead.",
+    'can_only_have_one_anchor': "Sorry, you cannot add more anchors to this ship.",
+
+    # Success Messages
+
+    'transport_renamed': "Congratulations! You have renamed this ship to {transport_name}.",
+    'transport_is_mine': "You are now the owner of {transport_name}.",
+    'cabin_created': "You have added a cabin to your ship!",
+    'anchor_added': "You added an anchor to the ship.",
+
+    # Status
+    'transport_anchor_activated': "Dropping the anchor!",
+    'transport_anchor_deactivated': "Raising the anchor. Full speed ahead!",
+}
+
+
+# Attributes found in a private transport
+PRIVATE_TRANSPORT_ATTRS = {
+
+    # Indicates whether I am a private transport or not
+    #   If this attribute is missing, it means I'm not a private transport!
+    'flag': 'private_transport',
+
+    # Indicates the name of my owner
+    #   If this attribute is missing, it mean I still don't have an owner
+    'owner_name': 'private_transport_owner',
+
+    # Indicates the maximum amount of cabins that fit this transport
+    'limit_cabins': 'private_transport_cabins_limit',
+
+    # The value of this attribute indicates which template I will use
+    # when creating a new cabin.
+    'cabin_template': 'private_transport_cabin_template',
+    'cabin_entrance_x': 'private_transport_cabin_entrance_x',
+    'cabin_entrance_y': 'private_transport_cabin_entrance_y',
+    'cabin_exit_x': 'private_transport_cabin_exit_x',
+    'cabin_exit_y': 'private_transport_cabin_exit_y',
+
+    # Anchor stuff
+    'anchored': 'private_transport_anchored',
+    # The value of this attribute indicates the speed the transport usually moves
+    # Set as the same as speed, if don't want weird behaviour
+    'base_speed': 'private_transport_base_speed',
+}
+
+
+# Attributes found in a private transport feature
+PRIVATE_TRANSPORT_FEATURE_ATTRS = {
+    'flag': 'private_transport_feature',
+    'type': 'private_transport_feature_type',
+    'id': 'private_transport_feature_id',
+}
+
+
+NEW_TRANSPORT_NAME = '{scroll_name} (owner - {player_name})'
+
+
+# Cabins
+
+CABINS_DIRECTORY = path.map2abs('/world_built/cabins')
+
+# Note: Default value for the limit of cabins for a private transport
+# when PRIVATE_TRANSPORT_ATTRS['limit_cabins'] (see above) is not set on
+# the transport. You don't need worry about this.
+CABIN_LIMIT_DEFAULT = 4
+
+CABIN_KEY_ARCHETYPE = 'cabin_key'
+CABIN_KEY_NAME = 'key to Cabin {id_}'
+CABIN_KEY_NAME_PL = 'keys to Cabin {id_}'
+CABIN_KEY_GENERATED_COUNT = 5
+
+EXTERNAL_CABIN_DOOR_ARCHETYPE = 'external_cabin_door'
+EXTERNAL_CABIN_DOOR_NAME = 'Cabin {id_}'
+
+INTERNAL_CABIN_DOOR_ARCHETYPE = 'internal_cabin_door'
+INTERNAL_CABIN_DOOR_ATTR_TRACKING_ID = 'private_transport_tracking_id'
+
+
+# Anchors
+
+ANCHOR_ARCHETYPE = 'anchor'
+ANCHOR_NAME = 'Anchor {id_}'
+
+ANCHOR_KEY_ARCHETYPE = 'anchor_key'
+ANCHOR_KEY_NAME = 'key to Anchor {id_}'
+ANCHOR_KEY_NAME_PL = 'keys to Anchor {id_}'
+ANCHOR_KEY_GENERATED_COUNT = 5
+
+
+# Feature keys
+
+FEATURE_KEY_SLAYING_PREFIX = 'private_transport_feature_id_'

--- a/maps/python/private_ship/create_cabin.py
+++ b/maps/python/private_ship/create_cabin.py
@@ -1,0 +1,288 @@
+"""
+Script that is called when the "Create cabin" scroll is applied.
+"""
+
+import os.path
+
+import Crossfire
+
+import private_ship.path as path
+from private_ship.common import ActionError
+from private_ship.common import InternalError
+from private_ship.common import check_if_player_inside_private_transport_they_own
+from private_ship.common import generate_feature_id
+from private_ship.common import get_player_transport
+from private_ship.common import get_private_transport_feature_type
+from private_ship.common import set_private_transport_feature_id
+from private_ship.common import set_private_transport_feature_type
+from private_ship.config import CABINS_DIRECTORY
+from private_ship.config import CABIN_KEY_ARCHETYPE
+from private_ship.config import CABIN_KEY_GENERATED_COUNT
+from private_ship.config import CABIN_KEY_NAME
+from private_ship.config import CABIN_KEY_NAME_PL
+from private_ship.config import CABIN_LIMIT_DEFAULT
+from private_ship.config import EXTERNAL_CABIN_DOOR_ARCHETYPE
+from private_ship.config import EXTERNAL_CABIN_DOOR_NAME
+from private_ship.config import FEATURE_KEY_SLAYING_PREFIX
+from private_ship.config import PLAYER_MESSAGES
+from private_ship.config import PRIVATE_TRANSPORT_ATTRS
+from private_ship.config import PRIVATE_TRANSPORT_FEATURE_ATTRS
+from private_ship.utils import iter_inv
+from private_ship.utils import log_error
+from private_ship.utils import send_error_to_player
+from private_ship.utils import send_info_to_player
+
+
+# Exceptions
+#
+# pylint: disable=missing-class-docstring
+
+class CannotCreateMoreCabins(ActionError):
+    msg = PLAYER_MESSAGES['cannot_create_more_cabins']
+
+
+# Logic
+#
+# pylint: disable=unused-argument
+
+# (player applies "Create cabin" scroll)
+# Check if player can use feature scroll (common)
+#   If not, inform the user and exit
+# If player is in a personal ship he owns and can use the scroll:
+#   Create cabin
+#   Generate cabin id
+#   Create cabin door
+#   Generate keys for this cabin
+
+def main():
+    """Called code"""
+
+    player = Crossfire.WhoIsActivator()
+    scroll = Crossfire.WhoAmI()
+
+    try:
+        check_if_player_can_use_scroll(player, scroll)
+        use_scroll(player, scroll)
+    except InternalError as err:
+        log_error(err.errmsg)
+        send_error_to_player(err.msg, player)
+        return
+    except ActionError as err:
+        send_error_to_player(err.msg, player)
+        return
+    except Exception as err:
+        send_error_to_player(InternalError.msg, player)
+        raise
+
+
+def check_if_player_can_use_scroll(player, scroll):
+    """Verify if player can use scroll
+
+    If the player cannot use the scroll, raise an ActionError, which
+    will contain the appropriate message to send to the player.
+
+    Otherwise (if the player can use the scroll and it would take
+    effect), this function is NOP.
+    """
+
+    # player must be inside a private transport that they own
+    check_if_player_inside_private_transport_they_own(player)
+
+    # number of cabins after applying the scroll must be <= cabin limit
+    transport = get_player_transport(player)
+    cabin_limit = get_cabin_limit(transport)
+    current_cabin_count = get_current_cabin_count(transport)
+    if current_cabin_count + 1 > cabin_limit:
+        raise CannotCreateMoreCabins
+
+    # everything okay
+
+
+def get_cabin_limit(transport):
+    """Get the maximum amount of cabins that a transport can
+    accomodate."""
+
+    value = transport.ReadKey(PRIVATE_TRANSPORT_ATTRS['limit_cabins'])
+
+    # check for default value
+    if not value:
+        return CABIN_LIMIT_DEFAULT
+
+    # check for invalid value
+    # .isdigit() check if all characters are digits, that way, `value` will
+    # only be valid if it is a str representing an integer
+    if not value.isdigit():
+        log_error(
+            "Private Transport: "
+            "Cannot read cabins limit '%s'. "
+            "Using default value instead..." % (value)
+        )
+        return CABIN_LIMIT_DEFAULT
+
+    # convert to int and return
+    value = int(value)
+    return value
+
+
+def get_current_cabin_count(transport):
+    """Discover how many cabins are in a transport right now."""
+
+    return sum(is_cabin_door(o) for o in iter_inv(transport))
+
+
+def is_cabin_door(obj):
+    """Return True if obj is a cabin door, False otherwise."""
+    return get_private_transport_feature_type(obj) == 'cabin'
+
+
+def use_scroll(player, scroll):
+    """Use the "Create cabin" scroll
+
+    After this operation, we will have:
+
+    - A cabin map built for the player
+    - A door inside the transport that leads to the cabin
+    - Keys that allow a non-owner of the transport to go to the cabin
+
+    The keys only work with the specific cabin door.
+
+    Oh, and the scroll will be removed :)
+    """
+
+    # Generate cabin id
+    id_ = generate_feature_id()
+
+    # Create cabin map
+    map_location = create_cabin_map(player, scroll, id_)
+
+    # Create cabin door and add it to the transport's inventory
+    create_cabin_door(player, scroll, map_location, id_)
+
+    # Remove the player and put him back on the transport so that the
+    # added cabin becomes visible
+    transport = get_player_transport(player)
+    transport.Apply(player, 0)
+    transport.Apply(player, 0)
+
+    # Create keys and add them to player inventory
+    create_cabin_keys(player, scroll, id_)
+
+    # Vanish with the scroll
+    # Note: Remove() will remove all stacked scrolls at once
+    scroll.Quantity -= 1
+
+    # Inform the player
+    inform_player_of_new_cabin_added(player, scroll, id_)
+
+
+def create_cabin_map(player, scroll, id_):
+    """Generate a new cabin map, based on a template, and return the
+    path to the generated map.
+
+    Returns:
+        (str) An absolute path to the generated map.
+    """
+
+    # pylint: disable=invalid-name
+
+    # Decide location to save map
+    map_location = get_map_location_for_cabin(player, scroll, id_)
+
+    # Decide template to use
+    template_file = decide_template_to_use(player, scroll)
+
+    # Read contents of template
+    with open(template_file, mode='r') as fp:
+        text = fp.read()
+
+    # Create new cabin file
+    with open(map_location, mode='w') as fp:
+        fp.write(text)
+
+    # Return the location of the cabin file
+    return map_location
+
+
+def get_map_location_for_cabin(player, scroll, id_):
+    """Get path that a certain cabin will be saved to."""
+
+    return os.path.join(
+        CABINS_DIRECTORY,
+        id_,
+    )
+
+
+def decide_template_to_use(player, scroll):
+    """Decide which template to use when creating a cabin map
+
+    Returns an *absolute* path to the template file.
+    """
+
+    transport = get_player_transport(player)
+    template = transport.ReadKey(PRIVATE_TRANSPORT_ATTRS['cabin_template'])
+    if not template:
+        raise InternalError(
+            "Failed to create cabin. Private transport without \"%s\" property."
+            "" % PRIVATE_TRANSPORT_ATTRS['cabin_template']
+        )
+    template_abs = path.map2abs(template)
+
+    return template_abs
+
+
+def create_cabin_door(player, scroll, map_location, id_):
+    """Create a door that leads to the cabin and add it to the transport
+
+    Args:
+        player
+        scroll
+        map_location: Absolute path corresponding to the cabin
+
+    Returns:
+        A reference to the created door.
+    """
+
+    transport = get_player_transport(player)
+
+    # Create door inside transport's inventory
+    door = transport.CreateObject(EXTERNAL_CABIN_DOOR_ARCHETYPE)
+    door.WriteKey(PRIVATE_TRANSPORT_FEATURE_ATTRS['flag'], '1', 1)
+    set_private_transport_feature_type(door, 'cabin')
+    set_private_transport_feature_id(door, id_)
+
+    # Set door name
+    door.Name = EXTERNAL_CABIN_DOOR_NAME.format(id_=id_)
+    door.NamePl = EXTERNAL_CABIN_DOOR_NAME.format(id_=id_)
+
+    # Link door to cabin
+    door.Slaying = path.abs2map(map_location)
+    door.HP = int(transport.ReadKey(PRIVATE_TRANSPORT_ATTRS['cabin_entrance_x']))
+    door.SP = int(transport.ReadKey(PRIVATE_TRANSPORT_ATTRS['cabin_entrance_y']))
+
+    return door
+
+
+def create_cabin_keys(player, scroll, id_):
+    """Create cabin keys and insert them into the player's inventory"""
+
+    keys = player.CreateObject(CABIN_KEY_ARCHETYPE)
+    keys.Slaying = FEATURE_KEY_SLAYING_PREFIX + id_
+    keys.Quantity = CABIN_KEY_GENERATED_COUNT
+    keys.Name = CABIN_KEY_NAME.format(id_=id_)
+    keys.NamePl = CABIN_KEY_NAME_PL.format(id_=id_)
+
+
+def inform_player_of_new_cabin_added(player, scroll, id_):
+    """Inform player that a new cabin has just been created."""
+
+    send_info_to_player(
+        PLAYER_MESSAGES['cabin_created'],
+        player,
+    )
+
+
+# prevent scroll apply
+Crossfire.SetReturnValue(1)
+
+# run script
+main()

--- a/maps/python/private_ship/external_cabin_door.py
+++ b/maps/python/private_ship/external_cabin_door.py
@@ -1,0 +1,114 @@
+"""
+Script used to teleport the player to the cabin when he uses an external
+cabin door.
+
+See also: create_cabin.py
+"""
+
+import Crossfire
+
+import tracking_system
+from private_ship.common import ActionError
+from private_ship.common import InternalError
+from private_ship.common import check_if_player_can_use_feature
+from private_ship.common import get_player_transport
+from private_ship.config import INTERNAL_CABIN_DOOR_ARCHETYPE
+from private_ship.config import INTERNAL_CABIN_DOOR_ATTR_TRACKING_ID
+from private_ship.config import PRIVATE_TRANSPORT_ATTRS
+from private_ship.utils import log_error
+from private_ship.utils import send_error_to_player
+from utils import iter_loc
+
+
+# (player applies cabin door)
+# Check if player can use feature (common)
+#   If not, inform the user and exit
+# If player is the owner or if he has a key
+#   Put player out of transport mode
+#   Teleport him to the cabin (map and coordinates)
+#     map and coordinates are saved in the door
+#   Keep track of transport or transport location
+
+
+def main():
+    """Main"""
+
+    player = Crossfire.WhoIsActivator()
+    door = Crossfire.WhoAmI()
+
+    try:
+        check_if_player_can_use_door(player, door)
+        use_door(player, door)
+    except InternalError as err:
+        log_error(err.errmsg)
+        send_error_to_player(err.msg, player)
+    except ActionError as err:
+        send_error_to_player(err.msg, player)
+    except Exception:
+        send_error_to_player(InternalError.msg, player)
+        raise
+
+
+def check_if_player_can_use_door(player, door):
+    """Check if the player can use door
+
+    If not possible, raise ActionError with the appropriate message for
+    the player.
+    """
+    check_if_player_can_use_feature(player, door)
+
+
+def use_door(player, door):
+    """Use the door
+
+    This will teleport the player inside the cabin and start tracking
+    the ship, so the player can return to it afterwards.
+    """
+
+    transport = get_player_transport(player)
+
+    # put player out of transport mode
+    #   (otherwise the client breaks down)
+    transport.Apply(player, 0)
+
+    # teleport player to the cabin
+
+    # get cabin map and entrance
+    cabin_map = door.Slaying
+    cabin_x = door.HP
+    cabin_y = door.SP
+    # prepare map
+    map_ = Crossfire.ReadyMap(cabin_map)
+    # teleport player
+    player.Teleport(map_, cabin_x, cabin_y)
+
+    # start tracking transport and save tracking ID to internal cabin door
+    transport_tracking_id = tracking_system.add_tracker(transport)
+    internal_cabin_door = find_internal_cabin_door(transport, map_)
+    internal_cabin_door.WriteKey(
+        INTERNAL_CABIN_DOOR_ATTR_TRACKING_ID,
+        transport_tracking_id,
+        1,
+    )
+
+
+def find_internal_cabin_door(transport, cabin_map):
+    """Find internal cabin door located at cabin_map
+
+    Returns:
+        The cabin door object, if it is found, None, otherwise.
+    """
+
+    # Get coordinates for the door
+    door_x = int(transport.ReadKey(PRIVATE_TRANSPORT_ATTRS['cabin_exit_x']))
+    door_y = int(transport.ReadKey(PRIVATE_TRANSPORT_ATTRS['cabin_exit_y']))
+    # Find cabin door
+    for obj in iter_loc(cabin_map, door_x, door_y):
+        if obj.Archetype.Name == INTERNAL_CABIN_DOOR_ARCHETYPE:
+            return obj
+    # Return None if not found
+    return None
+
+
+Crossfire.SetReturnValue(1)
+main()

--- a/maps/python/private_ship/idgen.py
+++ b/maps/python/private_ship/idgen.py
@@ -1,0 +1,50 @@
+"""
+ID generator for private transports and features they can have
+"""
+
+import os.path
+import sqlite3
+
+import Crossfire
+
+
+def generate():
+    """Generate a unique id for a private ship or a private ship
+    feature.
+
+    I will be using a database here, first, because it is easy to setup,
+    and second, because it deals with race conditions in a correct
+    manner. Implementing this is possible, but prone to errors.
+
+    Returns:
+        An ID (str) to be used with private ships and private ships
+        features.
+    """
+
+    # create database if it doesn't exist
+    conn = sqlite3.connect(get_db_location())
+
+    c = conn.cursor()
+
+    # create table if it doesn't exist
+    c.execute('create table if not exists id_generator (id integer primary key autoincrement)')
+
+    # insert new entry into table
+    c.execute('insert into id_generator values (NULL)')
+
+    # commit transaction
+    conn.commit()
+
+    # retrieve id of generated entry and convert to str
+    id_ = str(c.lastrowid)
+
+    # return id
+    return id_
+
+
+def get_db_location():
+    """Get path of database file we will use here"""
+    return os.path.join(
+        Crossfire.LocalDirectory(),
+        'private_transports_id_gen.db',
+    )

--- a/maps/python/private_ship/internal_cabin_door.py
+++ b/maps/python/private_ship/internal_cabin_door.py
@@ -1,0 +1,78 @@
+"""
+Script used to teleport the player back from a cabin to the transport.
+
+Activated when the players applies the door found in the cabin (internal door).
+"""
+
+import Crossfire
+
+import tracking_system
+from private_ship.config import INTERNAL_CABIN_DOOR_ATTR_TRACKING_ID
+from private_ship.config import PLAYER_MESSAGES
+from private_ship.utils import send_info_to_player
+from utils import log_error
+
+
+# (player attempts to leave cabin)
+# Get tracking ID from the internal door
+# Check if we managed to keep track of the ship location
+#   If not, teleport player to their home, apologize and exit
+# If we kept track of the ship
+#   Teleport player to ship location
+#   Put player in transport mode
+
+# ~~Stop tracking ship~~
+#   Do not stop tracking ship. The tracking system currently maintains
+#   only a number of trackers (it doesn't know WHO is tracking). So, say
+#   a players starts tracking a shipp, a DM that teleported to him could
+#   make this ship stop being tracked, which could cause a problem.
+#
+#   A bad side-effect is that the number of trackers will only increase,
+#   so a ship will never stop being tracked. This can be bad for good
+#   amounts of players.
+
+
+def main():
+    """Main script"""
+    player = Crossfire.WhoIsActivator()
+    door = Crossfire.WhoAmI()
+
+    id_ = get_tracking_id(door)
+    transport = tracking_system.get_object(id_)
+    if transport is None:
+        log_error('Lost private transport with tracking id %s' % id_)
+        log_error('Player affected: %s' % player.Name)
+        send_info_to_player(PLAYER_MESSAGES['lost_track_of_transport'], player)
+        teleport_player_to_bed(player)
+    else:
+        teleport_player_to_transport(player, transport)
+        transport.Apply(player, 0)
+
+
+def get_tracking_id(door):
+    """ Return the transport tracking ID found on the door, or ''"""
+    return door.ReadKey(INTERNAL_CABIN_DOOR_ATTR_TRACKING_ID)
+
+
+def teleport_player_to_bed(player):
+    """Teleport player to their bed"""
+
+    mapname = player.BedMap
+    bedx = player.BedX
+    bedy = player.BedY
+
+    flags = 2 if Crossfire.PlayerDirectory() in mapname else 0
+
+    map_ = Crossfire.ReadyMap(mapname, flags)
+    player.Teleport(map_, bedx, bedy)
+
+
+def teleport_player_to_transport(player, transport):
+    """Teleport a player to a transport
+
+    Assumes the transport is already loaded with its map.
+    """
+    player.Teleport(transport.Map, transport.X, transport.Y)
+
+
+main()

--- a/maps/python/private_ship/path.py
+++ b/maps/python/private_ship/path.py
@@ -1,0 +1,41 @@
+"""
+Path utilities for the private transport package
+
+(may be made general and work with other packages)
+
+Here I will make the convertion between:
+
+- Absolute paths: /usr/games/crossfire/share/crossfire/maps/scorn/shops/bank
+- Maps paths (relative to the 'maps' directory, in Crossfire format): /scorn/shops/bank
+
+Note: may not work on Windows
+"""
+
+import os.path
+
+import Crossfire
+
+
+MAPS_DIR = os.path.realpath(os.path.join(
+    Crossfire.DataDirectory(),
+    Crossfire.MapDirectory(),
+))
+
+
+def abs2map(abspath):
+    """Convert an absolute path to a path relative to the maps directory, in
+    Crossfire format."""
+
+    abspath = os.path.realpath(abspath)
+    relpath = os.path.relpath(abspath, MAPS_DIR)
+
+    return '/' + relpath
+
+
+def map2abs(mappath):
+    """Convert a map path (in Crossfire format) to an absolute path"""
+
+    relpath = mappath.lstrip('/')
+    abspath = os.path.join(MAPS_DIR, relpath)
+
+    return abspath

--- a/maps/python/private_ship/rename.py
+++ b/maps/python/private_ship/rename.py
@@ -1,0 +1,209 @@
+"""
+Ship rename scroll
+
+I run when a "Rename ship" scroll is applied.
+
+Private transports comes in 2 states:
+
+- Ownerless
+- Owned by someone
+
+Private transports are transports denoted with the attribute:
+
+    private_transport 1
+
+Note: I was using the term "private ship", but now I believe "private
+transport" is a better option and more general with what the game has to
+offer. There may be a mix, but always tending towards using transport.
+
+Original psedocode:
+  (player applies the scroll)
+  (this script is called)
+  VALIDATE ACTION
+  if scroll is not renamed
+    raise ScrollNotRenamed
+  if player not aboard anything
+    raise PlayerNotInsideTransport
+  if player aboard something which is not a private ship
+    raise PlayerInsideSomethingElse
+  if player aboard a private ship with a different owner
+    raise NotOwnerOfTheShip
+  (player is owner of the ship)
+  EXECUTE ACTION
+  if player aboard his own private ship
+    rename the ship
+    inform the player
+  if player aboard an ownerless private ship
+    rename the ship
+    set the owner of the ship
+    inform the player
+"""
+
+
+import Crossfire
+
+from private_ship.common import ActionError, InternalError
+from private_ship.common import check_if_player_inside_private_transport_they_own_or_can_own
+from private_ship.common import get_player_transport
+from private_ship.common import is_transport_owned_by_player
+from private_ship.config import NEW_TRANSPORT_NAME
+from private_ship.config import PLAYER_MESSAGES
+from private_ship.config import PRIVATE_TRANSPORT_ATTRS as ATTRS
+from private_ship.utils import send_error_to_player
+from private_ship.utils import send_info_to_player
+from utils import log_error
+
+
+# Exceptions
+
+class ScrollNotRenamed(ActionError):
+    msg = PLAYER_MESSAGES['scroll_not_renamed']
+
+
+# Logic
+
+def main():
+    """Execute the program when a Ship Rename Scroll is used
+    """
+
+    player = Crossfire.WhoIsActivator()
+    scroll = Crossfire.WhoAmI()
+
+    try:
+        check_if_player_can_use_scroll(player, scroll)
+        use_scroll(player, scroll)
+    except InternalError as err:
+        log_error(err.errmsg)
+        send_error_to_player(err.msg, player)
+        return
+    except ActionError as err:
+        send_error_to_player(err.msg, player)
+        return
+    except Exception as err:
+        send_error_to_player(InternalError.msg, player)
+        raise
+
+
+def check_if_player_can_use_scroll(player, scroll):
+    """Check if a player can use the Ship Rename Scroll
+
+    NOOP if they can, throw an ActionError if they can't.
+    """
+
+    scroll_name = get_scroll_custom_name(scroll)
+    if not scroll_name:
+        raise ScrollNotRenamed
+
+    check_if_player_inside_private_transport_they_own_or_can_own(player)
+
+
+def use_scroll(player, scroll):
+    """Make a player use a Ship Rename Scroll
+
+    Usage has already been validated, so player is on a private ship,
+    either one which is ownerless, or one which the player owns.
+    """
+    transport = get_player_transport(player)
+    if is_transport_owned_by_player(transport, player):
+        use_scroll_already_owned(player, scroll)
+    else:
+        use_scroll_new(player, scroll)
+
+
+def use_scroll_already_owned(player, scroll):
+    """Functionality for using a scroll when player already owns the transport
+
+    - rename the ship
+    - inform the player
+    - remove scroll
+    - put player out and into transport mode so the name of the ship updates
+    """
+
+    transport = get_player_transport(player)
+
+    scroll_name = get_scroll_custom_name(scroll)
+    transport_name = get_transport_name(scroll_name, player.Name)
+
+    rename_transport(transport, transport_name)
+
+    send_info_to_player(
+        PLAYER_MESSAGES['transport_renamed'].format(transport_name=scroll_name),
+        player)
+
+    # Move player out of transport and then into transport
+    # This way, the new name of the transport will appear
+    transport.Apply(player, 0)
+    transport.Apply(player, 0)
+
+    scroll.Quantity -= 1
+
+
+def use_scroll_new(player, scroll):
+    """Functionality for using a scroll when the transport is ownerless
+
+    - rename the transport
+    - set player as the owner
+    - inform the player
+    - remove scroll
+    - put player out and into transport mode so the name of the ship updates
+    """
+
+    transport = get_player_transport(player)
+    scroll_name = get_scroll_custom_name(scroll)
+    transport_name = get_transport_name(scroll_name, player.Name)
+
+    rename_transport(transport, transport_name)
+    set_transport_owner(transport, player)
+
+    send_info_to_player(
+        PLAYER_MESSAGES['transport_renamed'].format(transport_name=scroll_name),
+        player)
+    send_info_to_player(
+        PLAYER_MESSAGES['transport_is_mine'].format(transport_name=scroll_name),
+        player)
+
+    scroll.Quantity -= 1
+
+    # Move player out of transport and then into transport
+    # This way, the new name of the transport will appear
+    transport.Apply(player, 0)
+    transport.Apply(player, 0)
+
+
+def get_scroll_custom_name(scroll):
+    """Get the scroll custom_name
+
+    custom_name is set with the rename command
+    """
+    return scroll.CustomName
+
+
+def get_transport_name(scroll_name, player_name):
+    """Get the name of a transport"""
+    return NEW_TRANSPORT_NAME.format(
+        scroll_name=scroll_name,
+        player_name=player_name,
+    )
+
+
+def rename_transport(transport, name):
+    """Rename the transport
+    """
+    transport.Name = name
+    transport.NamePl = name
+
+
+def set_transport_owner(transport, player):
+    """Set player as the owner of transport"""
+    transport.WriteKey(
+        ATTRS['owner_name'],
+        player.Name,
+        1,
+    )
+
+
+# prevent scroll apply
+Crossfire.SetReturnValue(1)
+
+# run script
+main()

--- a/maps/python/private_ship/test.py
+++ b/maps/python/private_ship/test.py
@@ -1,0 +1,19 @@
+"""
+Script run when we apply a 'testpython' object
+
+This is NOT related to testing the private_ship functionalities, it is
+just a playground to test for features.
+"""
+
+import Crossfire
+
+
+log = lambda x: Crossfire.Log(Crossfire.LogInfo, repr(x))
+
+log(Crossfire.DataDirectory())
+log(Crossfire.MapDirectory())
+log(Crossfire.UniqueDirectory())
+log(Crossfire.LocalDirectory())
+
+# do not apply the object
+Crossfire.SetReturnValue(1)

--- a/maps/python/private_ship/utils.py
+++ b/maps/python/private_ship/utils.py
@@ -1,0 +1,33 @@
+"""
+Utilities for the private transports programs
+"""
+
+import Crossfire
+
+from private_ship.config import ERROR_MESSAGE_FLAGS
+from private_ship.config import INFORMATION_MESSAGE_FLAGS
+
+
+def iter_inv(obj):
+    """Iterate over all the objects in the inventory of an object"""
+    cur = obj.Inventory
+    while cur:
+        yield cur
+        cur = cur.Below
+
+
+def log_error(msg):
+    """Log error message"""
+    if not isinstance(msg, str):
+        msg = repr(msg)
+    Crossfire.Log(Crossfire.LogError, msg)
+
+
+def send_error_to_player(msg, player):
+    """Send error message to a player"""
+    player.Message(msg, ERROR_MESSAGE_FLAGS)
+
+
+def send_info_to_player(msg, player):
+    """Send information message to a player"""
+    player.Message(msg, INFORMATION_MESSAGE_FLAGS)

--- a/maps/python/tracking_system.py
+++ b/maps/python/tracking_system.py
@@ -1,0 +1,713 @@
+"""
+Implementation of the system that tracks objects
+
+Each object is assumed to have 0 or more trackers on top of it. Objects
+with more than 1 trackers (or 1 tracker) are tracked. Tracked objects
+can be retrieved using the get_object() function.
+
+Interface:
+
+    add_tracker(obj): Add a tracker to the obj and maybe update obj
+        location.
+    remove_tracker(tracking_id): Remove tracker from an object, given
+        its tracking ID.
+    get_object(tracking_id): Retrieve tracked object, given its tracking
+        ID.
+
+    Use it only with unique objects that cannot be picked up.
+
+    Behavior is undefined for pickable objects.
+
+Inner workings:
+
+    While in game, objects can exist in three states, basically:
+
+    - Live on a loaded map
+    - Live on an unloaded map
+    - Removed
+
+    We also assign a tracking ID to each object we track.
+
+    This system keeps track of objects, no matter what state they are
+    in.
+
+    Objects on a loaded map are saved in a dictionary (we call them
+    references).
+
+    Objects on an unloaded map are saved in a database (we call the data
+    saved coordinates).
+
+    Removed objects are marked as lost, for any user that want to search
+    for it later know that we lost it.
+
+    We capture system events to recognize when an object moves from one
+    state to another, and update our tracking method accordingly.
+
+Hooks:
+
+    There are 4 types of events that can be fired related to Crossfire maps:
+
+    - MAPLOAD: After a map is fully loaded, including objects on
+      the map (I had to change this a bit in the server code).
+    - FREE_OBJECTS: I created this event to signal me that all objects
+      are gonna be removed from a map.
+    - MAPRESET: Before resetting a map. Resetting a map will reset all
+      its objects except for the unique ones (and other unique-related
+      stuff (BTW, unique would be better named 'permanent').
+    - MAPUNLOAD: Before swapping out a map. The objects will still
+      be present there, except when it is the result of a RESET.
+    - SERVER_SHUTDOWN: I also created this event to signal that the
+      server is gonna be shut down. The MAPRESET and MAPUNLOAD were not
+      firing then, but I haven't tested FREE_OBJECTS.
+
+    The tracking system responds in the following way to each of these
+    events (converting only the necessary objects):
+
+    - load process:
+      - MAPLOAD -> coords2ref
+
+    - unload process:
+      - MAPUNLOAD -> ref2coords
+      - FREE_OBJECTS -> obj saved as coords, not affected
+
+    - reset process (the reason FREE_OBJECTS is needed):
+      - FREE_OBJECTS -> ref2coords
+      - MAPUNLOAD -> obj saved as coords, NOP
+      - FREE_OBJECTS -> obj saved as coords, NOP
+      - MAPRESET -> obj saved as coords, NOP
+
+    I left a hook for MAPUNLOAD, MAPRESET and SERVER_SHUTDOWN as backup
+    measure and because this won't hurt.
+
+Notes:
+
+    This code is intricate and has not been tested thoroughly, so, there
+    will certainly be errors.
+
+    I hope that my non-automated tests are enough to make it robust
+    enough.
+
+    It currently doesn't have a failsafe against server crashes or loss
+    of power, so, objects saved as refs when the server crashes will be
+    lost.
+
+    Also, thinking of this whole code as a finite state machine may be
+    useful. Actions can be made by the system or by the server/players
+    themselves. I was thinking of providing an image of this but I got
+    a bit lazy lol
+
+    This code could probably be easier implemeted (and be more useful)
+    if done in C. I don't know C, so, that's all you get :D
+"""
+
+import os.path
+import sqlite3
+
+import Crossfire
+
+from utils import iter_loc
+from utils import log_error
+
+
+DATABASE_NAME = 'tracking_system.db'
+
+FIELD_NAME_TRACKING_ID = 'tracking_id'
+
+TRACKING_METHOD_REF = 'by_ref'
+TRACKING_METHOD_COORDS = 'by_coord'
+TRACKING_METHOD_NONE = 'not_tracked'
+
+REFS_DICTIONARY_NAME = 'tracking_system_refs'
+
+
+class InvalidObjectError(Exception):
+    """When an object is invalid and this impossibilitate the execution
+    of the function you expected"""
+
+
+class ObjectNotTrackedError(Exception):
+    """When you try to retrieve an object reference, but it is not
+    tracked, we will issue an error"""
+
+
+class SubstitutingTrackingIdError(Exception):
+    """When you try to write the tracking id to an object that already
+    has it"""
+
+
+# Interface
+
+def add_tracker(object_):
+    """Add a tracker for object_ and return the object tracking ID"""
+
+    if not _is_object_valid(object_):
+        raise InvalidObjectError
+
+    tracking_id = _get_tracking_id(object_)
+    if tracking_id:
+        _increment_number_of_trackers(tracking_id)
+        _set_object_reference(tracking_id, object_)
+    else:
+        tracking_id = _generate_new_tracking_id()
+        _set_tracking_id(object_, tracking_id)
+        _increment_number_of_trackers(tracking_id)
+        _set_object_reference(tracking_id, object_)
+
+    return tracking_id
+
+
+def remove_tracker(tracking_id):
+    """Remove a tracker from an object, given its tracking_id"""
+
+    assert isinstance(tracking_id, str)
+    assert tracking_id.isdigit()
+
+    num_trackers = _decrement_number_of_trackers(tracking_id)
+    if num_trackers == 0:
+        _stop_tracking(tracking_id)
+
+
+def get_object(tracking_id, raise_on_no_trackers=False):
+    """Return a reference to an object, given its tracking_id
+
+    If the object cannot be found, return None.
+
+    If the object was not being tracked, raise an error when
+    raise_on_no_trackers = True. This is indicative of programming
+    error, because the number of trackers for an item shall remain
+    consistent.
+    """
+
+    assert isinstance(tracking_id, str)
+    assert tracking_id.isdigit()
+
+    if _get_number_of_trackers(tracking_id) == 0 and raise_on_no_trackers:
+        raise ObjectNotTrackedError
+
+    # get reference to obj or None
+    tracking_method = _get_tracking_method(tracking_id)
+    if tracking_method == TRACKING_METHOD_REF:
+        obj = _get_object_by_reference(tracking_id)
+    elif tracking_method == TRACKING_METHOD_COORDS:
+        obj = _get_object_by_coords(tracking_id)
+    elif tracking_method == TRACKING_METHOD_NONE:
+        obj = None
+    else:
+        raise RuntimeError('should not reach this line of code')
+
+    # mark object as lost if I can't find it
+    if obj is None and tracking_method != TRACKING_METHOD_NONE:
+        _mark_object_as_lost(tracking_id)
+
+    return obj
+
+
+# Inner workings
+
+def _is_object_valid(object_):
+    """Return True if an object is valid"""
+    # object is invalid if it is None
+    if object_ is None:
+        return False
+
+    # object is invalid if it has been freed
+    try:
+        object_.Removed
+    except ReferenceError:
+        return False
+
+    # object is valid if it has not been removed
+    return not object_.Removed
+
+
+def _get_tracking_id(object_):
+    """Return the tracking id of an object, or '', if it has none
+
+    The object is assumed to be valid.
+
+    Raises:
+        ReferenceError: if the object is freed.
+
+    Returns:
+        An str corresponding to the tracking id for the object.
+    """
+    return object_.ReadKey(FIELD_NAME_TRACKING_ID)
+
+
+def _set_tracking_id(object_, tracking_id):
+    """Set tracking id for an object.
+
+    The object is assumed to be valid.
+
+    Raises:
+        ReferenceError: if the object is freed.
+        SustitutingTrackingIdError: if the object already has a tracking
+            id.
+
+    Returns:
+        Nothing.
+    """
+    # check if the object already has a tracking id
+    # if it has, throw an Error
+    cur_id = _get_tracking_id(object_)
+    if cur_id:
+        raise SubstitutingTrackingIdError
+
+    # if it doesn't have, set it !
+    object_.WriteKey(FIELD_NAME_TRACKING_ID, tracking_id, 1)
+
+
+def _delete_tracking_id(object_):
+    """Delete the tracking id of an object.
+
+    The object is assumed to be valid.
+    """
+    # check if object has tracking id
+    # if not, warn the user and exit
+    cur_id = _get_tracking_id(object_)
+    if not cur_id:
+        _warn('Trying to remove tracking id from object without tracking id')
+        return
+    # delete tracking id
+    object_.WriteKey(FIELD_NAME_TRACKING_ID, '', 1)
+
+
+def _get_number_of_trackers(tracking_id):
+    """Return the number of trackers tracking an object"""
+    conn = _get_db_connection()
+    with conn:
+        # get row corresponding to tracking_id
+        cur = conn.cursor()
+        cur.execute(
+            'select num_trackers from tracked_objects where id=?',
+            (int(tracking_id),),
+        )
+        result = cur.fetchone()
+    conn.close()
+
+    # if no rows, return 0 (object is not tracked)
+    if result is None:
+        return 0
+
+    return result[0]
+
+
+def _increment_number_of_trackers(tracking_id):
+    """Increment number of trackers tracking an object
+
+    Returns:
+        (int) New number of trackers on the object.
+    """
+    conn = _get_db_connection()
+    with conn:
+        # get row corresponding to tracking_id
+        cur = conn.cursor()
+        cur.execute(
+            'select num_trackers from tracked_objects where id=?',
+            (int(tracking_id),),
+        )
+        result = cur.fetchone()
+
+        # if no row, create row
+        if result is None:
+            num_trackers = 1
+            cur.execute(
+                'insert into tracked_objects (id, num_trackers) values (?, ?)',
+                (int(tracking_id), num_trackers),
+            )
+        # if row, increment number of trackers
+        else:
+            num_trackers = result[0] + 1
+            cur.execute(
+                'update tracked_objects set num_trackers=? where id=?',
+                (num_trackers, int(tracking_id)),
+            )
+
+    conn.close()
+    return num_trackers
+
+
+def _decrement_number_of_trackers(tracking_id):
+    """Decrement number of trackers tracking an object
+
+    If the number is already 0, keep it at zero.
+
+    Returns:
+        (int) New number of trackers on the object.
+    """
+    conn = _get_db_connection()
+    with conn:
+        # get row corresponding to tracking_id
+        cur = conn.cursor()
+        cur.execute(
+            'select num_trackers from tracked_objects where id=?',
+            (int(tracking_id),),
+        )
+        result = cur.fetchone()
+
+        # if no row, warn user and exit
+        if result is None:
+            _warn('Trying to remove a tracker from an object that is not saved on the db.')
+            return 0
+
+        # if no trackers already, warn user and exit
+        if result[0] == 0:
+            _warn('Trying to remove a tracker from an object without trackers.')
+            return 0
+
+        # decrement number of trackers
+        num_trackers = result[0] - 1
+        cur.execute(
+            'update tracked_objects set num_trackers=? where id=?',
+            (num_trackers, int(tracking_id)),
+        )
+
+    conn.close()
+    return num_trackers
+
+
+def _get_tracking_method(tracking_id):
+    """Return the current tracking method used to track an object
+
+    Returns:
+        One of TRACKING_METHOD_, defined as contants
+    """
+
+    conn = _get_db_connection()
+    with conn:
+        cur = conn.cursor()
+        cur.execute(
+            'select method from tracked_objects where id=?',
+            (int(tracking_id),),
+        )
+        result = cur.fetchone()
+    conn.close()
+
+    if result is None:
+        return TRACKING_METHOD_NONE
+
+    return result[0]
+
+
+def _stop_tracking(tracking_id):
+    """Stop tracking an object"""
+
+    # remove tracking id from object (if found)
+    object_ = get_object(tracking_id, raise_on_no_trackers=False)
+    if object_ is not None:
+        _delete_tracking_id(object_)
+
+    # delete object reference
+    _delete_object_reference(tracking_id)
+
+    # clean object database row
+    conn = _get_db_connection()
+    with conn:
+        conn.execute(
+            'delete from tracked_objects where id=?',
+            (int(tracking_id),),
+        )
+    conn.close()
+
+
+def _set_object_reference(tracking_id, object_):
+    """Update the reference of an object and set its tracking method to
+    REF.
+
+    Raises:
+        InvalidObjectError: if object_ is invalid.
+    """
+    # check if object is valid
+    if not _is_object_valid(object_):
+        raise InvalidObjectError
+    # update reference
+    _get_objects_refs_dictionary()[tracking_id] = object_
+    # update tracking method to REF
+    conn = _get_db_connection()
+    with conn:
+        conn.execute(
+            'UPDATE tracked_objects '
+            'SET method=? '
+            'WHERE id=?',
+            (TRACKING_METHOD_REF, tracking_id),
+        )
+    conn.close()
+
+
+def _delete_object_reference(tracking_id):
+    """Remove the reference to an object"""
+    try:
+        del _get_objects_refs_dictionary()[tracking_id]
+    except KeyError:
+        _warn('Trying to remove reference for an object without reference saved')
+        return
+
+
+def _generate_new_tracking_id():
+    """Generate a new tracking ID
+
+    This will have the side effect of creating a database row and we use
+    it later.
+
+    Returns:
+        (str) A new tracking ID.
+    """
+    conn = _get_db_connection()
+    with conn:
+        cur = conn.cursor()
+        cur.execute(
+            'insert into tracked_objects (id, method, num_trackers) values (NULL,?,?)',
+            (TRACKING_METHOD_NONE, 0),
+        )
+        id_ = str(cur.lastrowid)
+    conn.close()
+    return id_
+
+
+def _get_object_by_reference(tracking_id):
+    """Return object whose reference has been saved
+
+    If object is not found, or if it is invalid, return None.
+    """
+    obj = _get_objects_refs_dictionary().get(tracking_id)
+    return obj if obj is not None and _is_object_valid(obj) else None
+
+
+def _get_object_by_coords(tracking_id):
+    """Get an object by saved coordinates
+
+    This will retrieve saved coordinates, and, if the map is not already
+    ready, instantiate the map and get a reference to the object.
+
+    The reference will be returned.
+
+    If the object cannot be found, return None.
+
+    Returns:
+        A reference to the object tracked by tracking_id, or None.
+    """
+    conn = _get_db_connection()
+    with conn:
+        cur = conn.cursor()
+        cur.execute(
+            'select mapname, coord_x, coord_y from tracked_objects where id=?',
+            (int(tracking_id),),
+        )
+        result = cur.fetchone()
+    conn.close()
+
+    if not result:
+        return None
+
+    # extract coordinates and map name
+    mapname, coord_x, coord_y = result
+
+    # instantiate map
+    map_ = Crossfire.ReadyMap(mapname)
+    # if not possible, return None
+    if map_ is None:
+        _warn("Could not ready map %s for object with tracking id %s" % (mapname, tracking_id))
+        return None
+
+    # get reference to object
+    # (and return)
+    return _get_object_in_map(tracking_id, map_, coord_x, coord_y)
+
+
+def _mark_object_as_lost(tracking_id):
+    """We lost the reference to a certain object, mark it as lost"""
+    # mark it as lost in the database
+    conn = _get_db_connection()
+    conn.execute(
+        'update tracked_objects set method=? where id=?',
+        (TRACKING_METHOD_NONE, int(tracking_id)),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _is_object_on_map(object_, map_):
+    """Return true if object_ still exists and is on map_"""
+    o = object_
+    m = map_
+    return object_.Exists and not object_.Removed and object_.Map == map_
+
+
+def _get_object_in_map(tracking_id, map_, coord_x, coord_y):
+    """Return a reference to the object with tracking_id sitting at map_
+
+    If the object cannot be found at coord_x / coord_y, return None.
+
+    Args:
+        tracking_id: The tracking_id of the object to be found.
+        map_: The map (already readied) where the object will be
+            searched for.
+        coord_x: the X coordinate we expect the item to be in.
+        coord_y: The Y coordinate we expect the item to be in.
+
+    Returns:
+        A reference to the object in the map, or None, if the object was
+        not found.
+    """
+
+    assert isinstance(tracking_id, str)
+
+    for obj in iter_loc(map_, coord_x, coord_y):
+        if _get_tracking_id(obj) == tracking_id:
+            return obj
+    # obj was not found
+    return None
+
+
+def _ref_to_coords(tracking_id):
+    """Convert tracking method of an object from REF to COORDS"""
+
+    object_ = _get_object_by_reference(tracking_id)
+
+    # remove REF
+    _delete_object_reference(tracking_id)
+
+    # add coords (uses obj)
+    mapname = object_.Map.Path
+    coord_x = object_.X
+    coord_y = object_.Y
+    conn = _get_db_connection()
+    with conn:
+        conn.execute(
+            'UPDATE tracked_objects '
+            'SET method=?, mapname=?, coord_x=?, coord_y=? '
+            'WHERE id=?',
+            (TRACKING_METHOD_COORDS, mapname, coord_x, coord_y, tracking_id),
+        )
+    conn.close()
+
+
+def _coords_to_ref(tracking_id, object_):
+    """Convert tracking method of an object from COORDS to REF"""
+
+    # add ref
+    _set_object_reference(tracking_id, object_)
+
+    # remove coords
+    conn = _get_db_connection()
+    with conn:
+        conn.execute(
+            'UPDATE tracked_objects '
+            'SET method=? '
+            'WHERE id=?',
+            (TRACKING_METHOD_REF, tracking_id),
+        )
+    conn.close()
+
+
+def _get_db_connection():
+    """Return sqlite3.Connection for the database we are using
+
+    This will also initialize the required tables for use.
+    """
+
+    # get location of db
+    loc = _get_db_location()
+
+    # initialize connection object
+    conn = sqlite3.connect(loc)
+
+    # create table if they don't exist
+    # (trying to create the table every time is inefficient but fast enough)
+    conn.execute('''
+        create table if not exists tracked_objects (
+            id integer primary key autoincrement,
+            method text,
+            num_trackers integer,
+            mapname text,
+            coord_x integer,
+            coord_y integer
+        )
+    ''')
+
+    return conn
+
+
+def _get_db_location():
+    """Return the location for the sqlite3 database we will be using"""
+    return os.path.join(
+        Crossfire.LocalDirectory(),
+        DATABASE_NAME,
+    )
+
+
+def _get_objects_refs_dictionary():
+    # this script is gonna be imported by another, therefore, we need to
+    # use the shared dict
+    private_d = Crossfire.GetSharedDictionary()
+    # create dictionary if it doesn't exist
+    if private_d.get(REFS_DICTIONARY_NAME) is None:
+        private_d[REFS_DICTIONARY_NAME] = {}
+    return private_d[REFS_DICTIONARY_NAME]
+
+
+# Hooks
+
+def hook_freeobjects(map_):
+    """Hook called on EVENT_FREE_OBJECTS
+
+    Objects are being removed from a map. Convert all tracked objects
+    there into coordinates.
+
+    Good references are converted into map coordinates and saved to the
+    database.
+
+    Bad references are dropped out and we mark the object as lost.
+    """
+    for tracking_id, object_ in _get_objects_refs_dictionary().items():
+        if _is_object_on_map(object_, map_):
+            if _is_object_valid(object_):
+                _ref_to_coords(tracking_id)
+            else:
+                _mark_object_as_lost(tracking_id)
+
+
+def hook_mapload(map_):
+    """Hook called on EVENT_MAPLOAD
+
+    A map is loading. Convert all tracked objects in this map to
+    references.
+
+    Good coordinates are converted into object references and saved to
+    the refs dictionary.
+
+    Bad coordinates are dropped out and we mark the object as lost.
+
+    Note: The event should (and does) come after the objects have been
+    loaded.
+    """
+
+    mapname = map_.Path
+
+    # get objects on map
+    conn = _get_db_connection()
+    with conn:
+        cur = conn.cursor()
+        cur.execute(
+            'SELECT id, coord_x, coord_y '
+            'FROM tracked_objects '
+            'WHERE mapname = ? AND method = ? AND num_trackers >= 1',
+            (mapname, TRACKING_METHOD_COORDS),
+        )
+        results = cur.fetchall()
+    conn.close()
+
+    # iterate over objects
+    for tracking_id, coord_x, coord_y in results:
+        tracking_id = str(tracking_id)
+        object_ = _get_object_in_map(tracking_id, map_, coord_x, coord_y)
+        if object_ is not None:
+            _coords_to_ref(tracking_id, object_)
+        else:
+            _mark_object_as_lost(tracking_id)
+
+
+# Utils
+
+def _warn(msg):
+    log_error("Tracking system: %s" % msg)

--- a/maps/python/utils.py
+++ b/maps/python/utils.py
@@ -1,0 +1,42 @@
+"""
+I have general utilities.
+"""
+
+import Crossfire
+
+
+def iter_loc(map_, coordinate_x, coordinate_y):
+    """Iterate over all object at location x/y on map_"""
+    obj = map_.ObjectAt(coordinate_x, coordinate_y)
+    while obj is not None:
+        yield obj
+        obj = obj.Above
+
+
+def iter_inv(obj):
+    """Iterate over all the objects in the inventory of an object"""
+    cur = obj.Inventory
+    while cur:
+        yield cur
+        cur = cur.Below
+
+
+def log_error(msg):
+    """Log error message"""
+    if not isinstance(msg, str):
+        msg = repr(msg)
+    Crossfire.Log(Crossfire.LogError, msg)
+
+
+def log_info(msg):
+    """Log info message"""
+    if not isinstance(msg, str):
+        msg = repr(msg)
+    Crossfire.Log(Crossfire.LogInfo, msg)
+
+
+def log_debug(msg):
+    """Log debug message (visible from debug mode)"""
+    if not isinstance(msg, str):
+        msg = repr(msg)
+    Crossfire.Log(Crossfire.LogDebug, msg)

--- a/maps/test/private_transports/cabin_template
+++ b/maps/test/private_transports/cabin_template
@@ -1,0 +1,161 @@
+arch map
+name cabin_simpletemplate
+width 6
+height 6
+msg
+Created:  2020-11-26 Titus
+Modified: 2020-11-26 dre (lowerthansound)
+endmsg
+end
+arch woodfloor
+end
+arch woodfloor
+y 1
+end
+arch woodfloor
+y 2
+end
+arch woodfloor
+y 3
+end
+arch woodfloor
+y 4
+end
+arch woodfloor
+y 5
+end
+arch woodfloor
+x 1
+end
+arch woodfloor
+x 1
+y 1
+end
+arch woodfloor
+x 1
+y 2
+end
+arch woodfloor
+x 1
+y 3
+end
+arch woodfloor
+x 1
+y 4
+end
+arch woodfloor
+x 1
+y 5
+end
+arch woodfloor
+x 2
+end
+arch woodfloor
+x 2
+y 1
+end
+arch woodfloor
+x 2
+y 2
+end
+arch woodfloor
+x 2
+y 3
+end
+arch woodfloor
+x 2
+y 4
+end
+arch woodfloor
+x 2
+y 5
+end
+arch woodfloor
+x 3
+end
+arch woodfloor
+x 3
+y 1
+end
+arch woodfloor
+x 3
+y 2
+end
+arch woodfloor
+x 3
+y 3
+end
+arch woodfloor
+x 3
+y 4
+end
+arch woodfloor
+x 3
+y 5
+end
+arch woodfloor
+x 4
+end
+arch woodfloor
+x 4
+y 1
+end
+arch woodfloor
+x 4
+y 2
+end
+arch woodfloor
+x 4
+y 3
+end
+arch woodfloor
+x 4
+y 4
+end
+arch woodfloor
+x 4
+y 5
+end
+arch woodfloor
+x 5
+end
+arch woodfloor
+x 5
+y 1
+end
+arch woodfloor
+x 5
+y 2
+end
+arch woodfloor
+x 5
+y 3
+end
+arch woodfloor
+x 5
+y 4
+end
+arch woodfloor
+x 5
+y 5
+end
+
+arch sign
+msg
+You need to use an internal_cabin_door for the exit of a cabin
+Also, set the private_transport_cabin_exit_x and private_transport_cabin_exit_y correctly on the private transport for this to work.
+The program will locate the door with the archetype at the given coordinates.
+Cya :)
+endmsg
+x 0
+y 4
+end
+
+arch internal_cabin_door
+arch event_apply
+title Python
+slaying /python/private_ship/internal_cabin_door.py
+end
+x 1
+y 4
+end

--- a/maps/test/private_transports/example_personal_ship
+++ b/maps/test/private_transports/example_personal_ship
@@ -1,0 +1,604 @@
+# This maps provides an example for the usage of personal (private) ships.
+# 
+# Personal ships are referred to a private transports in the code, because
+# that's what I started with, and transports provide a more general view,
+# however, I believe "personal" is a better word for users.
+# 
+# This map was initially created by Titus and then modified to provide an
+# example by lowerthansound (me!), who is also working on the general
+# functionality for private transports.
+#
+# Note: these comment are not comments, they will throw errors in your
+# Crossfire server, but, it's fine lol (we need a way to create comments
+# in map files)
+# 
+# Created:  2020-11-13 Titus
+# Modified: 2020-11-26 dre (lowerthansound)
+
+
+arch map
+name example_personal_ship
+width 10
+height 10
+end
+arch sea
+end
+arch sea
+y 1
+end
+arch sea
+y 2
+end
+arch sea
+y 3
+end
+arch sea
+y 4
+end
+arch sea
+y 5
+end
+arch grass
+y 6
+end
+arch grass
+y 7
+end
+arch grass
+y 8
+end
+arch grass
+y 9
+end
+arch sea
+x 1
+end
+arch sea
+x 1
+y 1
+end
+arch sea
+x 1
+y 2
+end
+arch sea
+x 1
+y 3
+end
+arch sea
+x 1
+y 4
+end
+arch sea
+x 1
+y 5
+end
+arch grass
+x 1
+y 6
+end
+arch grass
+x 1
+y 7
+end
+arch grass
+x 1
+y 8
+end
+arch grass
+x 1
+y 9
+end
+arch sea
+x 2
+end
+arch sea
+x 2
+y 1
+end
+arch sea
+x 2
+y 2
+end
+arch sea
+x 2
+y 3
+end
+arch sea
+x 2
+y 4
+end
+arch sea
+x 2
+y 5
+end
+arch grass
+x 2
+y 6
+end
+arch grass
+x 2
+y 7
+end
+arch grass
+x 2
+y 8
+end
+arch grass
+x 2
+y 9
+end
+arch sea
+x 3
+end
+arch sea
+x 3
+y 1
+end
+arch sea
+x 3
+y 2
+end
+arch sea
+x 3
+y 3
+end
+arch sea
+x 3
+y 4
+end
+arch sea
+x 3
+y 5
+end
+arch grass
+x 3
+y 6
+end
+arch grass
+x 3
+y 7
+end
+arch grass
+x 3
+y 8
+end
+arch grass
+x 3
+y 9
+end
+arch sea
+x 4
+end
+arch sea
+x 4
+y 1
+end
+arch sea
+x 4
+y 2
+end
+arch sea
+x 4
+y 3
+end
+arch sea
+x 4
+y 4
+end
+arch sea
+x 4
+y 5
+end
+arch grass
+x 4
+y 6
+end
+arch grass
+x 4
+y 7
+end
+arch grass
+x 4
+y 8
+end
+arch grass
+x 4
+y 9
+end
+arch sea
+x 5
+end
+arch sea
+x 5
+y 1
+end
+arch sea
+x 5
+y 2
+end
+arch sea
+x 5
+y 3
+end
+arch sea
+x 5
+y 4
+end
+arch sea
+x 5
+y 5
+end
+arch grass
+x 5
+y 6
+end
+arch grass
+x 5
+y 7
+end
+arch grass
+x 5
+y 8
+end
+arch grass
+x 5
+y 9
+end
+arch sea
+x 6
+end
+arch sea
+x 6
+y 1
+end
+arch sea
+x 6
+y 2
+end
+arch sea
+x 6
+y 3
+end
+arch sea
+x 6
+y 4
+end
+arch sea
+x 6
+y 5
+end
+arch grass
+x 6
+y 6
+end
+arch grass
+x 6
+y 7
+end
+arch grass
+x 6
+y 8
+end
+arch grass
+x 6
+y 9
+end
+arch sea
+x 7
+end
+arch sea
+x 7
+y 1
+end
+arch sea
+x 7
+y 2
+end
+arch sea
+x 7
+y 3
+end
+arch sea
+x 7
+y 4
+end
+arch sea
+x 7
+y 5
+end
+arch grass
+x 7
+y 6
+end
+arch grass
+x 7
+y 7
+end
+arch grass
+x 7
+y 8
+end
+arch grass
+x 7
+y 9
+end
+arch sea
+x 8
+end
+arch sea
+x 8
+y 1
+end
+arch sea
+x 8
+y 2
+end
+arch sea
+x 8
+y 3
+end
+arch sea
+x 8
+y 4
+end
+arch sea
+x 8
+y 5
+end
+arch grass
+x 8
+y 6
+end
+arch grass
+x 8
+y 7
+end
+arch grass
+x 8
+y 8
+end
+arch grass
+x 8
+y 9
+end
+arch sea
+x 9
+end
+arch sea
+x 9
+y 1
+end
+arch sea
+x 9
+y 2
+end
+arch sea
+x 9
+y 3
+end
+arch sea
+x 9
+y 4
+end
+arch sea
+unique 1
+x 9
+y 5
+end
+arch grass
+x 9
+y 6
+end
+arch grass
+x 9
+y 7
+end
+arch grass
+x 9
+y 8
+end
+arch grass
+x 9
+y 9
+end
+
+
+
+# Signs and such
+
+arch sign
+msg
+Scrolls
+endmsg
+x 3
+y 9
+end
+
+arch sign
+msg
+A personal ship.
+endmsg
+x 0
+y 6
+end
+
+arch sign
+msg
+A personal ship with owner set.
+endmsg
+x 3
+y 6
+end
+
+arch sign
+msg
+A personal ship (for easy copy-pasting).
+endmsg
+x 0
+y 0
+end
+
+arch sign
+msg
+The sea above has the unique flag set on it.
+Leave a boat here to save it between resets.
+Note: Use usual resets instead of full-resets !
+endmsg
+x 9
+y 6
+end
+
+arch scroll
+msg
+This is a map where you can test the functionality of a private ship.
+See map code for comments.
+endmsg
+x 0
+y 8
+end
+
+
+
+# Personal Ships
+
+
+# This is the archetype of a personal ship
+# Use this as a reference for the properties needed :)
+
+arch galleon
+name Personal Ship
+
+# Flag used to indicate that this is a private transport
+# Set to 1
+private_transport 1
+
+# Maximum amount of cabins on the ship
+# Set as a number from 0 to whatever you want :)
+private_transport_cabins_limit 3
+
+# Base speed of the ship
+# Used when raising an anchor to determine the speed of the ship
+# Set to the same value as 'speed'
+private_transport_base_speed 0.5
+
+# Cabin information
+# Set cabin_template to the location of the template you will use
+# Set cabin_entrance to the coordinates of the entrance of the cabin
+# Set cabin_exit to the coordinates of the exit of the cabin (the internal door)
+private_transport_cabin_template /test/private_transports/cabin_template
+private_transport_cabin_entrance_x 0
+private_transport_cabin_entrance_y 0
+private_transport_cabin_exit_x 1
+private_transport_cabin_exit_y 4
+
+speed 0.5
+type 2
+weight 100
+container 10000000
+passenger_limit 2
+move_type swim boat
+move_block swim boat
+move_allow walk
+x 0
+y 5
+end
+
+
+# This is the archetype of a personal ship without comments
+# For easy copypastas
+
+arch galleon
+name Personal Ship (for easy copy-pasta)
+private_transport 1
+private_transport_cabins_limit 3
+private_transport_base_speed 0.5
+private_transport_cabin_template /test/private_transports/cabin_template
+private_transport_cabin_entrance_x 0
+private_transport_cabin_entrance_y 0
+private_transport_cabin_exit_x 1
+private_transport_cabin_exit_y 4
+speed 0.5
+type 2
+weight 100
+container 10000000
+passenger_limit 2
+move_type swim boat
+move_block swim boat
+move_allow walk
+x 1
+y 0
+end
+
+
+# This is a personal ship with the 'owner' property set
+# Use for fast tests
+
+arch galleon
+name Personal Ship (owner - dm)
+private_transport 1
+private_transport_owner dm
+private_transport_cabins_limit 3
+private_transport_base_speed 0.5
+private_transport_cabin_template /test/private_transports/cabin_template
+private_transport_cabin_entrance_x 0
+private_transport_cabin_entrance_y 0
+private_transport_cabin_exit_x 1
+private_transport_cabin_exit_y 4
+speed 0.5
+type 2
+weight 100
+container 10000000
+passenger_limit 1
+move_type swim boat
+move_block swim boat
+move_allow walk
+x 3
+y 5
+end
+
+
+
+# Scrolls
+
+arch rename_ship_scroll
+name Rename ship
+face scroll.111
+nrof 5
+material 1
+weight 200
+arch event_apply
+title Python
+slaying /python/private_ship/rename.py
+end
+x 4
+y 9
+end
+
+arch create_cabin_scroll
+name Create cabin
+face scroll.111
+nrof 5
+material 1
+weight 200
+arch event_apply
+title Python
+slaying /python/private_ship/create_cabin.py
+end
+x 5
+y 9
+end
+
+arch add_anchor_scroll
+name Add anchor
+face scroll.111
+nrof 5
+material 1
+weight 200
+arch event_apply
+title Python
+slaying /python/private_ship/add_anchor.py
+end
+x 6
+y 9
+end

--- a/maps/test/private_transports/private_ships
+++ b/maps/test/private_transports/private_ships
@@ -1,0 +1,445 @@
+arch map
+name ship_test
+width 10
+height 10
+msg
+This is the original test created by Titus.
+It is left here as a record.
+Use /test/private_transports/example_personal_ship now
+Created:  2020-11-13 Titus
+Modified: 2020-11-13 Titus
+endmsg
+end
+arch sea
+end
+arch sea
+y 1
+end
+arch sea
+y 2
+end
+arch sea
+y 3
+end
+arch sea
+y 4
+end
+arch sea
+y 5
+end
+arch grass
+y 6
+end
+arch grass
+y 7
+end
+arch grass
+y 8
+end
+arch grass
+y 9
+end
+arch sea
+x 1
+end
+arch sea
+x 1
+y 1
+end
+arch sea
+x 1
+y 2
+end
+arch sea
+x 1
+y 3
+end
+arch sea
+x 1
+y 4
+end
+arch sea
+x 1
+y 5
+end
+arch grass
+x 1
+y 6
+end
+arch grass
+x 1
+y 7
+end
+arch scroll
+name Instructions
+msg
+Table accepts 1 gold coin per generated item
+DM command to reset map: reset full-reset .   <don't forget the period at the end
+endmsg
+x 1
+y 7
+end
+arch grass
+x 1
+y 8
+end
+arch grass
+x 1
+y 9
+end
+arch sea
+x 2
+end
+arch sea
+x 2
+y 1
+end
+arch sea
+x 2
+y 2
+end
+arch sea
+x 2
+y 3
+end
+arch sea
+x 2
+y 4
+end
+arch sea
+x 2
+y 5
+end
+arch galleon
+name Test Boat (public)
+name_pl toy boats
+x 2
+y 5
+speed 0.5
+type 2
+weight 100
+container 10000000
+move_type swim boat
+move_allow 0
+passenger_limit 1
+end
+arch grass
+x 2
+y 6
+end
+arch grass
+x 2
+y 7
+end
+arch grass
+x 2
+y 8
+end
+arch grass
+x 2
+y 9
+end
+arch sea
+x 3
+end
+arch sea
+x 3
+y 1
+end
+arch sea
+x 3
+y 2
+end
+arch sea
+x 3
+y 3
+end
+arch sea
+x 3
+y 4
+end
+arch sea
+x 3
+y 5
+end
+arch grass
+x 3
+y 6
+end
+arch grass
+x 3
+y 7
+end
+arch grass
+x 3
+y 8
+end
+arch grass
+x 3
+y 9
+end
+arch sea
+x 4
+end
+arch sea
+x 4
+y 1
+end
+arch sea
+x 4
+y 2
+end
+arch sea
+x 4
+y 3
+end
+arch sea
+x 4
+y 4
+end
+arch sea
+x 4
+y 5
+end
+arch grass
+x 4
+y 6
+end
+arch grass
+x 4
+y 7
+end
+arch grass
+x 4
+y 8
+end
+arch grass
+x 4
+y 9
+end
+arch sea
+x 5
+end
+arch sea
+x 5
+y 1
+end
+arch sea
+x 5
+y 2
+end
+arch sea
+x 5
+y 3
+end
+arch sea
+x 5
+y 4
+end
+arch sea
+x 5
+y 5
+end
+arch grass
+x 5
+y 6
+end
+arch grass
+x 5
+y 7
+end
+arch grass
+x 5
+y 8
+end
+arch grass
+x 5
+y 9
+end
+arch sea
+x 6
+end
+arch sea
+x 6
+y 1
+end
+arch sea
+x 6
+y 2
+end
+arch sea
+x 6
+y 3
+end
+arch sea
+x 6
+y 4
+end
+arch sea
+x 6
+y 5
+end
+arch grass
+x 6
+y 6
+end
+arch grass
+x 6
+y 7
+end
+arch grass
+x 6
+y 8
+end
+arch grass
+x 6
+y 9
+end
+arch sea
+x 7
+end
+arch sea
+x 7
+y 1
+end
+arch sea
+x 7
+y 2
+end
+arch sea
+x 7
+y 3
+end
+arch sea
+x 7
+y 4
+end
+arch sea
+x 7
+y 5
+end
+arch galleon
+name Test Boat (personal)
+name_pl toy boats
+private_transport 1
+x 7
+y 5
+speed 0.5
+type 2
+weight 100
+container 10000000
+move_type swim boat
+move_allow 0
+passenger_limit 1
+end
+arch grass
+x 7
+y 6
+end
+arch grass
+x 7
+y 7
+end
+arch grass
+x 7
+y 8
+end
+arch grass
+x 7
+y 9
+end
+arch sea
+x 8
+end
+arch sea
+x 8
+y 1
+end
+arch sea
+x 8
+y 2
+end
+arch sea
+x 8
+y 3
+end
+arch sea
+x 8
+y 4
+end
+arch sea
+x 8
+y 5
+end
+arch grass
+x 8
+y 6
+end
+arch grass
+x 8
+y 7
+end
+arch grass
+x 8
+y 8
+end
+arch grass
+x 8
+y 9
+end
+arch sea
+x 9
+end
+arch sea
+x 9
+y 1
+end
+arch sea
+x 9
+y 2
+end
+arch sea
+x 9
+y 3
+end
+arch sea
+x 9
+y 4
+end
+arch sea
+x 9
+y 5
+end
+arch grass
+x 9
+y 6
+end
+arch grass
+x 9
+y 7
+end
+arch dragon_steak_table
+name Scroll Table
+food 1
+x 9
+y 7
+arch rename_ship_scroll
+arch event_apply
+title Python
+slaying /python/private_ship/rename.py
+end
+end
+end
+arch grass
+x 9
+y 8
+end
+arch goldcoin
+x 9
+y 8
+nrof 1
+end
+arch grass
+x 9
+y 9
+end

--- a/maps/world_built/cabins/README
+++ b/maps/world_built/cabins/README
@@ -1,0 +1,1 @@
+See /python/private_ship for more information :)


### PR DESCRIPTION
Changes:

- Update `.gitignore`: Hide some built maps that were being tracked by git.
- Create `maps/python/utils.py` with some general utilities
- Create `maps/python/tracking_system.py`: A system to keep track of unique objects across server resets.
- Create `maps/python/private_ship`: Scripts related with the private transports.
- Create `maps/test/private_transports`: Some test maps for the private transports!

See also: https://github.com/TitusCF/crossfire-server/pull/3 and https://github.com/Partmedia/crossfire-arch/pull/3